### PR TITLE
[Patch] Check for number of threads on CPU instead of cores

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -690,7 +690,7 @@ void GenerateDynamics(bool fGenerate, int nThreads, const CChainParams& chainpar
     static boost::thread_group* minerThreads = NULL;
 
     if (nThreads < 0)
-        nThreads = GetNumCores();
+        nThreads = boost::thread::hardware_concurrency(); // Number of Cores don't equal to number of threads
 
     if (minerThreads != NULL)
     {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -690,7 +690,7 @@ void GenerateDynamics(bool fGenerate, int nThreads, const CChainParams& chainpar
     static boost::thread_group* minerThreads = NULL;
 
     if (nThreads < 0)
-        nThreads = boost::thread::hardware_concurrency(); // Number of Cores don't equal to number of threads
+        nThreads = boost::thread::hardware_concurrency(); // Number of Cores are not equal to the number of threads 
 
     if (minerThreads != NULL)
     {


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?

Check for number of threads on CPU instead of cores so that accurate numbers are derived when 'setgenerate true -1' is passed

#### Was this PR tested and how? (If testing is not needed, please explain why)

Ubuntu 16.04 LTS
