### PR TITLE
Improved Argon2d for AVX2

### DIFF
--- a/qa/pull-tester/run-dynamicd-for-test.sh
+++ b/qa/pull-tester/run-dynamicd-for-test.sh
@@ -3,14 +3,14 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
-DATADIR="/home/wolf/Downloads/Dynamic/.dynamic"
+DATADIR="/home/wolf/Downloads/Dynamic-wolf/.dynamic"
 rm -rf "$DATADIR"
 mkdir -p "$DATADIR"/regtest
 touch "$DATADIR/regtest/debug.log"
 tail -q -n 1 -F "$DATADIR/regtest/debug.log" | grep -m 1 -q "Done loading" &
 WAITER=$!
 PORT=`expr 10000 + $$ % 55536`
-"/home/wolf/Downloads/Dynamic/src/dynamicd" -connect=0.0.0.0 -datadir="$DATADIR" -rpcuser=user -rpcpassword=pass -listen -keypool=3 -debug -debug=net -logtimestamps -checkmempool=0 -relaypriority=0 -port=$PORT -whitelist=127.0.0.1 -regtest -rpcport=`expr $PORT + 1` &
+"/home/wolf/Downloads/Dynamic-wolf/src/dynamicd" -connect=0.0.0.0 -datadir="$DATADIR" -rpcuser=user -rpcpassword=pass -listen -keypool=3 -debug -debug=net -logtimestamps -checkmempool=0 -relaypriority=0 -port=$PORT -whitelist=127.0.0.1 -regtest -rpcport=`expr $PORT + 1` &
 DYNAMICD=$!
 
 #Install a watchdog.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -167,8 +167,7 @@ public:
         if(startNewChain == true) { MineGenesis(genesis, consensus.powLimit, true); }
 
         consensus.hashGenesisBlock = genesis.GetHash();
-		printf("Genesis Hash: 0x%s\n", consensus.hashGenesisBlock.GetHex().c_str());
-		
+        		
         if(!startNewChain) {
             assert(consensus.hashGenesisBlock == uint256S("0x00000ce9ce63ee661a41dd01fccaa4407e28e684cf925c58c87374082f07806d"));
             assert(genesis.hashMerkleRoot == uint256S("0xe89257a8e8dc153acd33b55c571d4b4878fce912cc4e334c2a4bddcd3cbbfcc9"));

--- a/src/crypto/argon2d/argon2.h
+++ b/src/crypto/argon2d/argon2.h
@@ -326,6 +326,8 @@ ARGON2_PUBLIC size_t argon2_encodedlen(uint32_t t_cost, uint32_t m_cost,
                                        uint32_t parallelism, uint32_t saltlen,
                                        uint32_t hashlen, argon2_type type);
 
+#ifdef __AVX2__
+
 ///////////////////////////
 // Wolf's Additions
 ///////////////////////////
@@ -333,6 +335,8 @@ ARGON2_PUBLIC size_t argon2_encodedlen(uint32_t t_cost, uint32_t m_cost,
 void WolfArgon2dPoWHash(void *Output, void *Matrix, const void *BlkHdr);
 void WolfArgon2dAllocateCtx(void **Matrix);
 void WolfArgon2dFreeCtx(void *Matrix);
+
+#endif
 
 #if defined(__cplusplus)
 }

--- a/src/hash.h
+++ b/src/hash.h
@@ -257,7 +257,7 @@ void BIP32Hash(const ChainCode &chainCode, unsigned int nChild, unsigned char he
     /// Threads: 2 threads
     /// Time Constraint: 1 iteration
 inline int Argon2d_Phase1_Hash(const void *in, void *out) {
-	/*argon2_context context;
+	argon2_context context;
     context.out = (uint8_t *)out;
     context.outlen = (uint32_t)OUTPUT_BYTES;
     context.pwd = (uint8_t *)in;
@@ -277,44 +277,18 @@ inline int Argon2d_Phase1_Hash(const void *in, void *out) {
     context.threads = 1;  // Threads
     context.t_cost = 1;   // Iterations
 
-    return argon2_ctx(&context, Argon2_d);*/
-    
-    void *Matrix;
-    
-    WolfArgon2dAllocateCtx(&Matrix);
-    WolfArgon2dPoWHash(out, Matrix, in);
-    WolfArgon2dFreeCtx(Matrix);
-    
-    return(0);
+    return argon2_ctx(&context, Argon2_d);
 }
 
-inline int Argon2d_Phase1_Hash_Ctx(const void *in, void *Matrix, void *out) {
-	/*argon2_context context;
-    context.out = (uint8_t *)out;
-    context.outlen = (uint32_t)OUTPUT_BYTES;
-    context.pwd = (uint8_t *)in;
-    context.pwdlen = (uint32_t)INPUT_BYTES;
-    context.salt = (uint8_t *)in; //salt = input
-    context.saltlen = (uint32_t)INPUT_BYTES;
-    context.secret = NULL;
-    context.secretlen = 0;
-    context.ad = NULL;
-    context.adlen = 0;
-    context.allocate_cbk = NULL;
-    context.free_cbk = NULL;
-    context.flags = DEFAULT_ARGON2_FLAG; // = ARGON2_DEFAULT_FLAGS
-    // main configurable Argon2 hash parameters
-    context.m_cost = 250; // Memory in KiB (~256KB)
-    context.lanes = 4;    // Degree of Parallelism
-    context.threads = 1;  // Threads
-    context.t_cost = 1;   // Iterations
+#ifdef __AVX2__
 
-    return argon2_ctx(&context, Argon2_d);*/
-        
+inline int Argon2d_Phase1_Hash_Ctx(const void *in, void *Matrix, void *out) {        
     WolfArgon2dPoWHash(out, Matrix, in);
         
     return(0);
 }
+
+#endif
 
     /// Argon2d Phase 2 Hash parameters for the next 5 years after phase 1
     /// Salt and password are the block header.
@@ -374,6 +348,8 @@ inline uint256 hash_Argon2d(const void* input, const unsigned int& hashPhase) {
     return hashResult;
 }
 
+#ifdef __AVX2__
+
 inline uint256 hash_Argon2d_ctx(const void* input, void *Matrix, const unsigned int& hashPhase) {
     uint256 hashResult;
     const uint32_t MaxInt32 = std::numeric_limits<uint32_t>::max();
@@ -392,5 +368,7 @@ inline uint256 hash_Argon2d_ctx(const void* input, void *Matrix, const unsigned 
     }
     return hashResult;
 }
+
+#endif
 
 #endif // DYNAMIC_HASH_H

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -531,9 +531,13 @@ void static DynamicMiner(const CChainParams& chainparams)
     boost::shared_ptr<CReserveScript> coinbaseScript;
     GetMainSignals().ScriptForMining(coinbaseScript);
 	
+	#ifdef __AVX2__
+	
 	void *Ctx;
 	
 	WolfArgon2dAllocateCtx(&Ctx);
+	
+	#endif
 	
     try {
         // Throw an error if no script was provided.  This can happen
@@ -596,7 +600,12 @@ void static DynamicMiner(const CChainParams& chainparams)
                 uint256 hash;
                 while (true)
                 {
+					#ifdef __AVX2__
                     hash = pblock->GetHashWithCtx(Ctx);
+                    #else
+                    hash = pblock->GetHash();
+                    #endif
+                    
                     if (UintToArith256(hash) <= hashTarget)
                     {
                         // Found a solution
@@ -678,17 +687,24 @@ void static DynamicMiner(const CChainParams& chainparams)
     catch (const boost::thread_interrupted&)
     {
         LogPrintf("DynamicMiner -- terminated\n");
+        
+        #ifdef __AVX2__
         WolfArgon2dFreeCtx(Ctx);
+        #endif
         throw;
     }
     catch (const std::runtime_error &e)
     {
         LogPrintf("DynamicMiner -- runtime error: %s\n", e.what());
+        #ifdef __AVX2__
         WolfArgon2dFreeCtx(Ctx);
+        #endif
         return;
     }
     
+    #ifdef __AVX2__
     WolfArgon2dFreeCtx(Ctx);
+    #endif
 }
 
 void GenerateDynamics(bool fGenerate, int nThreads, const CChainParams& chainparams)

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -68,10 +68,14 @@ public:
         return hash_Argon2d(UVOIDBEGIN(nVersion), 1);
     }
     
+    #ifdef __AVX2__
+    
     uint256 GetHashWithCtx(void *Matrix) const
     {
 		return(hash_Argon2d_ctx(UVOIDBEGIN(nVersion), Matrix, 1));
 	}
+	
+	#endif
 
     int64_t GetBlockTime() const
     {


### PR DESCRIPTION
Improved Argon2d; this implementation is for AVX2, yet maintains compatibility with CPUs without AVX2 support. To build with AVX2 optimizations (only if your CPU supports it will it work):

CPPFLAGS=-march=native CXXFLAGS=-march=native ./configure

Normal builds (without modified CPPFLAGS/CXXFLAGS) will not include the new optimizations.
