### PR TITLE
[Fluid] Add fluid history RPC command in clear text

### DIFF
--- a/src/rpcfluid.cpp
+++ b/src/rpcfluid.cpp
@@ -1,26 +1,6 @@
-/**
- * Copyright 2017 Everybody and Nobody (Empinel/Plaxton)
- *
- * This file is a portion of the DynamicX Protocol
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation files
- * (the "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject
- * to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
- * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
- * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
- * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
- * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
- * USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
+// Copyright (c) 2017 Duality Blockchain Solutions Developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "fluid.h"
 
@@ -300,7 +280,20 @@ UniValue consenttoken(const UniValue& params, bool fHelp)
     return result;
 }
 
-UniValue fluidcommandshistory(const UniValue& params, bool fHelp) {
+UniValue getfluidhistoryraw(const UniValue& params, bool fHelp) {
+    if (fHelp || params.size() != 0)
+        throw std::runtime_error(
+            "getfluidhistory\n"
+            "\nReturns raw data about each fluid command confirmed on the Dynamic blockchain.\n"
+            "\nResult:\n"
+            "{                   (json array of string)\n"
+            "  \"raw_command\"     (string) The operation code and raw fluid script command\n"
+            "}, ...\n"
+            "\nExamples\n"
+            + HelpExampleCli("getfluidhistoryraw", "")
+            + HelpExampleRpc("getfluidhistoryraw", "")
+        );
+
     GetLastBlockIndex(chainActive.Tip());
     CBlockIndex* pindex = chainActive.Tip();
     CFluidEntry fluidIndex = pindex->fluidParams;
@@ -309,10 +302,71 @@ UniValue fluidcommandshistory(const UniValue& params, bool fHelp) {
     UniValue obj(UniValue::VOBJ);
 
     BOOST_FOREACH(const std::string& existingRecord, transactionRecord) {
-        obj.push_back(Pair("fluidCommand", existingRecord)); // We will make it a pair with timestamp later
+        obj.push_back(Pair("raw_command", existingRecord));
     }
 
     return obj;
+}
+
+UniValue getfluidhistory(const UniValue& params, bool fHelp) {
+    if (fHelp || params.size() != 0)
+        throw std::runtime_error(
+            "getfluidhistory\n"
+            "\nReturns data about each fluid command confirmed on the Dynamic blockchain.\n"
+            "\nResult:\n"
+            "[                   (json array of object)\n"
+            "  {                 (json object)\n"
+            "  \"order\"           (string) order of execution.\n"
+            "  \"operation\"       (string) The fluid operation code.\n"
+            "  \"amount\"          (string) The fluid operation amount.\n"
+            "  \"timestamp\"       (string) The fluid operation timestamp\n"
+            "  \"payment_address\" (string) The fluid operation payment address\n"
+            "  }, ...\n"
+            "]\n"
+            "\nExamples\n"
+            + HelpExampleCli("getfluidhistory", "")
+            + HelpExampleRpc("getfluidhistory", "")
+        );
+
+    GetLastBlockIndex(chainActive.Tip());
+    CBlockIndex* pindex = chainActive.Tip();
+    CFluidEntry fluidIndex = pindex->fluidParams;
+    std::vector<std::string> transactionRecord = fluidIndex.fluidHistory;
+
+    UniValue ret(UniValue::VARR);
+    unsigned int order = 1;
+    HexFunctions hexConvert;
+    for (const std::string& existingRecord : transactionRecord) {
+        UniValue obj(UniValue::VOBJ);
+        obj.push_back(Pair("order", strprintf("%u", order)));
+        std::string strOperationCode = GetRidOfScriptStatement(existingRecord, 0);
+        obj.push_back(Pair("operation", strOperationCode));
+        std::string verificationWithoutOpCode = GetRidOfScriptStatement(existingRecord);
+
+        std::string strUnHexedFluidOpScript = hexConvert.HexToString(verificationWithoutOpCode);
+        std::vector<std::string> vecSplitScript;
+        SeperateFluidOpString(strUnHexedFluidOpScript, vecSplitScript);
+        if (vecSplitScript.size() > 1) {
+            std::string strAmount = vecSplitScript[0];
+            std::string strTimeStamp = vecSplitScript[1];
+            CAmount fluidAmount;
+            if (ParseFixedPoint(strAmount, 8, &fluidAmount)) {
+                obj.push_back(Pair("amount", strAmount));
+            }
+            int64_t tokenTimeStamp;
+            if (ParseInt64(strTimeStamp, &tokenTimeStamp)) {
+                obj.push_back(Pair("timestamp", strTimeStamp)); 
+            }
+            if (strOperationCode == "OP_MINT" && vecSplitScript.size() > 2) {
+                obj.push_back(Pair("payment_address", vecSplitScript[2]));
+            }
+            // TODO (Amir): Add signature addresses
+        }
+        ret.push_back(obj);
+        order +=1;
+    }
+    
+    return ret;
 }
 
 UniValue getfluidmasters(const UniValue& params, bool fHelp) {

--- a/src/rpcfluid.cpp
+++ b/src/rpcfluid.cpp
@@ -283,11 +283,11 @@ UniValue consenttoken(const UniValue& params, bool fHelp)
 UniValue getfluidhistoryraw(const UniValue& params, bool fHelp) {
     if (fHelp || params.size() != 0)
         throw std::runtime_error(
-            "getfluidhistory\n"
+            "getfluidhistoryraw\n"
             "\nReturns raw data about each fluid command confirmed on the Dynamic blockchain.\n"
             "\nResult:\n"
             "{                   (json array of string)\n"
-            "  \"raw_command\"     (string) The operation code and raw fluid script command\n"
+            "  \"fluid command\"     (string) The operation code and raw fluid script command\n"
             "}, ...\n"
             "\nExamples\n"
             + HelpExampleCli("getfluidhistoryraw", "")
@@ -302,7 +302,7 @@ UniValue getfluidhistoryraw(const UniValue& params, bool fHelp) {
     UniValue obj(UniValue::VOBJ);
 
     BOOST_FOREACH(const std::string& existingRecord, transactionRecord) {
-        obj.push_back(Pair("raw_command", existingRecord));
+        obj.push_back(Pair("fluid command", existingRecord));
     }
 
     return obj;
@@ -320,7 +320,7 @@ UniValue getfluidhistory(const UniValue& params, bool fHelp) {
             "  \"operation\"       (string) The fluid operation code.\n"
             "  \"amount\"          (string) The fluid operation amount.\n"
             "  \"timestamp\"       (string) The fluid operation timestamp\n"
-            "  \"payment_address\" (string) The fluid operation payment address\n"
+            "  \"payment address\" (string) The fluid operation payment address\n"
             "  }, ...\n"
             "]\n"
             "\nExamples\n"
@@ -358,7 +358,7 @@ UniValue getfluidhistory(const UniValue& params, bool fHelp) {
                 obj.push_back(Pair("timestamp", strTimeStamp)); 
             }
             if (strOperationCode == "OP_MINT" && vecSplitScript.size() > 2) {
-                obj.push_back(Pair("payment_address", vecSplitScript[2]));
+                obj.push_back(Pair("payment address", vecSplitScript[2]));
             }
             // TODO (Amir): Add signature addresses
         }
@@ -370,6 +370,19 @@ UniValue getfluidhistory(const UniValue& params, bool fHelp) {
 }
 
 UniValue getfluidsovereigns(const UniValue& params, bool fHelp) {
+    if (fHelp || params.size() != 0)
+        throw std::runtime_error(
+            "getfluidsovereigns\n"
+            "\nReturns the active sovereign addresses.\n"
+            "\nResult:\n"
+            "{                         (json array of string)\n"
+            "  \"sovereign address\"     (string) A sovereign address with permission to co-sign a fluid command\n"
+            "}, ...\n"
+            "\nExamples\n"
+            + HelpExampleCli("getfluidsovereigns", "")
+            + HelpExampleRpc("getfluidsovereigns", "")
+        );
+
     GetLastBlockIndex(chainActive.Tip());
     CBlockIndex* pindex = chainActive.Tip();
     CFluidEntry fluidIndex = pindex->fluidParams;

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -415,9 +415,10 @@ static const CRPCCommand vRPCCommands[] =
     { "Protocol",           "getrawpubkey",	 		  &getrawpubkey,		   true  },
     { "Protocol",           "verifyquorum",	 		  &verifyquorum,		   true  },
     { "Protocol",           "maketoken",	 		  &maketoken,		  	   true  },
-    { "Protocol",           "fluidcommandshistory",	  &fluidcommandshistory,   true  },
+    { "Protocol",           "getfluidhistory",        &getfluidhistory,        true  },
+    { "Protocol",           "getfluidhistoryraw",	  &getfluidhistoryraw,     true  },
     { "Protocol",           "getfluidmasters",	      &getfluidmasters,   	   true  },
-    { "Protocol",           "gettime",	      		  &gettime,   	   			true  },
+    { "Protocol",           "gettime",	      		  &gettime,   	   		   true  },
 #endif // ENABLE_WALLET
 };
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -410,16 +410,15 @@ static const CRPCCommand vRPCCommands[] =
 
     /* Fluid Protocol */
     { "Protocol",           "sendfluidtransaction",	  &sendfluidtransaction,   true  },
-    { "Protocol",           "signtoken",			        &signtoken,			         true  },
-    { "Protocol",           "consenttoken",			      &consenttoken,		       true  },
-    { "Protocol",           "getrawpubkey",	 		      &getrawpubkey,		       true  },
-    { "Protocol",           "verifyquorum",	 		      &verifyquorum,		       true  },
-    { "Protocol",           "maketoken",	 		        &maketoken,		  	       true  },
+    { "Protocol",           "signtoken",			  &signtoken,			   true  },
+    { "Protocol",           "consenttoken",			  &consenttoken,		   true  },
+    { "Protocol",           "getrawpubkey",	 		  &getrawpubkey,		   true  },
+    { "Protocol",           "verifyquorum",	 		  &verifyquorum,		   true  },
+    { "Protocol",           "maketoken",	 		  &maketoken,		  	   true  },
     { "Protocol",           "getfluidhistory",        &getfluidhistory,        true  },
-    { "Protocol",           "getfluidhistoryraw",	    &getfluidhistoryraw,     true  },
-    { "Protocol",           "getfluidmasters",	      &getfluidsovereigns,     true  },
-    { "Protocol",           "fluidcommandshistory",	  &fluidcommandshistory,   true  },
-    { "Protocol",           "gettime",	      		    &gettime,   	   		     true  },
+    { "Protocol",           "getfluidhistoryraw",	  &getfluidhistoryraw,     true  },
+    { "Protocol",           "getfluidsovereigns",	      &getfluidsovereigns,     true  },
+    { "Protocol",           "gettime",	      		  &gettime,   	   		   true  },
 #endif // ENABLE_WALLET
 };
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -316,7 +316,8 @@ extern UniValue getrawpubkey(const UniValue& params, bool fHelp);
 extern UniValue verifyquorum(const UniValue& params, bool fHelp);
 extern UniValue maketoken(const UniValue& params, bool fHelp);
 extern UniValue stringtohash(const UniValue& params, bool fHelp);
-extern UniValue fluidcommandshistory(const UniValue& params, bool fHelp);
+extern UniValue getfluidhistory(const UniValue& params, bool fHelp);
+extern UniValue getfluidhistoryraw(const UniValue& params, bool fHelp);
 extern UniValue getfluidmasters(const UniValue& params, bool fHelp);
 
 bool StartRPC();

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -689,7 +689,26 @@ void SeperateString(std::string input, std::vector<std::string> &output, bool su
 		boost::split(output, input, boost::is_any_of(SubDelimiter));
 	else
 		boost::split(output, input, boost::is_any_of(PrimaryDelimiter));
-};
+}
+
+void SeperateFluidOpString(std::string input, std::vector<std::string> &output) {
+  std::vector<std::string> firstSplit;
+  SeperateString(input, firstSplit);
+  if (firstSplit.size() > 1) {
+    std::vector<std::string> secondSplit;
+    SeperateString(firstSplit[0], secondSplit, true);
+    for (const std::string& item : secondSplit) {
+      output.push_back(item);
+    }
+    unsigned int n = 0;
+    for (const std::string& item : firstSplit) {
+      if (n != 0) {
+        output.push_back(item);
+      }
+      n =+1;
+    }
+  }
+}
 
 std::string StitchString(std::string stringOne, std::string stringTwo, bool subDelimiter) {
 	if(subDelimiter)

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -172,6 +172,7 @@ public:
 
 void ScrubString(std::string &input, bool forInteger = false);
 void SeperateString(std::string input, std::vector<std::string> &output, bool subDelimiter = false);
+void SeperateFluidOpString(std::string input, std::vector<std::string> &output);
 std::string StitchString(std::string stringOne, std::string stringTwo, bool subDelimiter = false);
 std::string StitchString(std::string stringOne, std::string stringTwo, std::string stringThree, bool subDelimiter = false);
 std::string GetRidOfScriptStatement(std::string input, int position = 1);


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
- add new command getfluidhistory that displays fluid command discrete fields
- rename fluidcommandshistory to getfluidhistoryraw
- add help and example for both RPC commands

![dynamic-fluid-dynode_getfluidhistory_command_20171209](https://user-images.githubusercontent.com/7564876/33794288-62c6ceea-dc8e-11e7-9a04-96861900b6e8.png)
