### PR TITLE
4th (Do not merge until release).  Frozen account stub for fluid.

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -159,6 +159,7 @@ public:
     unsigned int dynodeRecipientCount;
 	std::vector<std::string> fluidHistory;
 	std::vector<std::string> fluidSovereigns;
+	std::vector<std::string> fluidFrozenAccounts;
 
 	CFluidEntry() {
         SetNull();
@@ -172,6 +173,7 @@ public:
         READWRITE(VARINT(dynodeRecipientCount));
 		READWRITE(fluidHistory);
 		READWRITE(fluidSovereigns);
+		READWRITE(fluidFrozenAccounts);
 	}
 
     inline friend bool operator==(const CFluidEntry &a, const CFluidEntry &b) {
@@ -180,7 +182,8 @@ public:
 			&& a.fluidSovereigns == b.fluidSovereigns
 			&& a.blockReward == b.blockReward
 			&& a.dynodeReward == b.dynodeReward
-            && a.dynodeRecipientCount == b.dynodeRecipientCount
+			&& a.dynodeRecipientCount == b.dynodeRecipientCount
+			&& a.fluidFrozenAccounts == b.fluidFrozenAccounts
 			);
     }
 
@@ -189,7 +192,8 @@ public:
 		fluidSovereigns = b.fluidSovereigns;
 		blockReward = b.blockReward;
 		dynodeReward = b.dynodeReward;
-        dynodeRecipientCount = b.dynodeRecipientCount;
+		dynodeRecipientCount = b.dynodeRecipientCount;
+		fluidFrozenAccounts = b.fluidFrozenAccounts;
 		return *this;
     }
 
@@ -198,15 +202,16 @@ public:
     }
     
     inline void SetNull() { 
-		fluidHistory.clear(); 
+		fluidHistory.clear();
 		fluidSovereigns = InitialiseAddresses();
+		fluidFrozenAccounts.clear();
 		blockReward = 0;
 		dynodeReward = 0;
-        dynodeRecipientCount = 1;
+		dynodeRecipientCount = 1;
 	}
 
     inline bool IsNull() const { 
-		return (fluidHistory.empty() && fluidSovereigns == InitialiseAddresses() && blockReward == 0 && dynodeReward == 0 && dynodeRecipientCount == 1); 
+		return (fluidHistory.empty() && fluidSovereigns == InitialiseAddresses() && fluidFrozenAccounts.empty() && blockReward == 0 && dynodeReward == 0 && dynodeRecipientCount == 1); 
 	}
 };
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -176,13 +176,11 @@ public:
             assert(genesis.hashMerkleRoot == uint256S("0x3e924e261a371e799520120a67c24209fa087c78506f046ef61f1527b08d451b"));
         }
 
-        //TODO (Amir): Put back DNS seeders
-/*      
         vSeeds.push_back(CDNSSeedData("dnsseeder.io", "dyn2.dnsseeder.io"));
         vSeeds.push_back(CDNSSeedData("dnsseeder.com", "dyn2.dnsseeder.com"));
         vSeeds.push_back(CDNSSeedData("dnsseeder.host", "dyn2.dnsseeder.host"));
         vSeeds.push_back(CDNSSeedData("dnsseeder.net", "dyn2.dnsseeder.net"));
-*/
+
         // Dynamic addresses start with 'D'
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,30);
         // Dynamic script addresses start with '5'

--- a/src/fluid.h
+++ b/src/fluid.h
@@ -34,29 +34,21 @@ public:
     static const CAmount FLUID_MAX_REWARD_FOR_MINING = 1000 * COIN; // Max mining block reward using fluid OP_REWARD_MINING
     static const CAmount FLUID_MAX_FOR_MINT = 1000000000 * COIN; // Max minting amount per fluid transaction
 
-    std::vector<std::string> InitialiseAddresses() {
-        std::vector<std::string> x;
-        x.push_back("D9avNWVBmaUNevMNnkcLMrQpze8M2mKURu"); // CEO
-        x.push_back("DBwfYAiK2FPDDvoFXQFWaL4rU76KjEckkG"); // CTO
-        x.push_back("DHkD6oBQ5PtCiKo4wX8CRWrG61Vy5hEu4t"); // CFO
-        x.push_back("DKyqamefa7YdbqrP5pdTfNVVuq1gerNhMH"); // COO
-        x.push_back("DUDE1zFKK4fezCgcxdGbFh4yHJMcg8qpoP"); // CDOO
+    std::vector<std::pair<std::string, CDynamicAddress>> InitialiseSovereignIdentities() {
+        std::vector<std::pair<std::string, CDynamicAddress>> x;
+        x.push_back(std::make_pair("CEO",   CDynamicAddress("D9avNWVBmaUNevMNnkcLMrQpze8M2mKURu")));
+        x.push_back(std::make_pair("CTO",   CDynamicAddress("DBwfYAiK2FPDDvoFXQFWaL4rU76KjEckkG")));
+        x.push_back(std::make_pair("CFO",   CDynamicAddress("DHkD6oBQ5PtCiKo4wX8CRWrG61Vy5hEu4t")));
+        x.push_back(std::make_pair("COO",   CDynamicAddress("DKyqamefa7YdbqrP5pdTfNVVuq1gerNhMH")));
+        x.push_back(std::make_pair("CDOO",  CDynamicAddress("DUDE1zFKK4fezCgcxdGbFh4yHJMcg8qpoP")));
         return x;
     }
 
-    std::vector<std::string> InitialiseIdentities() {
-        std::vector<std::string> x;
-        x.push_back("ChickenFishAndChips");
-        x.push_back("AvanaTheMermaid");
-        x.push_back("PomphretFish");
-        x.push_back("LudicrousLunch");
-        x.push_back("PromiscuousPanda");
-        return x;
-    }
+    std::vector<std::string> InitialiseAddresses();
 };
 
 /** Fluid Asset Management Framework */
-class Fluid : public CFluidParameters, public HexFunctions {
+class CFluid : public CFluidParameters, public HexFunctions {
 public:
     void AddFluidTransactionsToRecord(const CBlockIndex* pblockindex, std::vector<std::string>& transactionRecord);
     void ReplaceFluidSovereigns(const CBlockHeader& blockHeader, std::vector<std::string>& fluidSovereigns);
@@ -96,6 +88,6 @@ CAmount getDynodeSubsidyWithOverride(CAmount lastOverrideCommand, bool fDynode =
 void BuildFluidInformationIndex(CBlockIndex* pindex, CAmount &nExpectedBlockValue, bool fDynodePaid);
 bool IsTransactionFluid(CScript txOut);
 
-extern Fluid fluid;
+extern CFluid fluid;
 
 #endif // FLUID_PROTOCOL_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2232,7 +2232,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
 			
 			FluidIndex.fluidHistory = fluidHistory;
 			
-			for (uint32_t x = 0; x != fluid.InitialiseIdentities().size(); x++) {
+			for (uint32_t x = 0; x != fluid.InitialiseSovereignIdentities().size(); x++) {
 				/* std::string error;
 				CDynamicAddress inputKey; // Reinitialise at each iteration to reset value
 				CNameVal val = nameValFromString(fluid.InitialiseIdentities().at(x));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -408,7 +408,6 @@ static void SendMoney(const CTxDestination &address, CAmount nValue, bool fSubtr
 
 void SendCustomTransaction(const CScript generatedScript, CWalletTx& wtxNew, CAmount nValue)
 {
-    // TODO (Amir): Add minimum height and spork activate OP_MINT.  Add checks to mempool and create transaction as well
     CAmount curBalance = pwalletMain->GetBalance();
 
     // Check amount


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
- Add frozen account vector to CFluidEntry for later use.

Adding `std::vector<std::string> fluidFrozenAccounts` to `CFluidEntry` forced a block re-index but the wallet still works since the new vector hasn't been used and is empty.