### PR TITLE
Update getfluidhistory RPC output, Adds Sovereign Addresses

### DIFF
--- a/src/fluid.h
+++ b/src/fluid.h
@@ -75,6 +75,7 @@ public:
     bool ProvisionalCheckTransaction(const CTransaction &transaction);
     bool CheckTransactionToBlock(const CTransaction &transaction, const CBlockHeader& blockHeader);
     bool ProcessFluidToken(const std::string consentToken, std::vector<std::string> &ptrs, int strVecNo);
+    CDynamicAddress GetAddressFromDigestSignature(std::string digestSignature, std::string messageTokenKey);
 };
 
 /** Standard Reward Payment Determination Functions */

--- a/src/rpcfluid.cpp
+++ b/src/rpcfluid.cpp
@@ -308,29 +308,6 @@ UniValue getfluidhistoryraw(const UniValue& params, bool fHelp) {
     return obj;
 }
 
-static std::string GetAddressFromDigestSignature(std::string digestSignature, std::string messageTokenKey) {
-    bool fInvalid = false;
-    std::vector<unsigned char> vchSig = DecodeBase64(digestSignature.c_str(), &fInvalid);
-
-    if (fInvalid) {
-        LogPrintf("GenericVerifyInstruction(): Digest Signature Found Invalid, Signature: %s \n", digestSignature);
-        return false;
-    }
-
-    CHashWriter ss(SER_GETHASH, 0);
-    ss << strMessageMagic;
-    ss << messageTokenKey;
-
-    CPubKey pubkey;
-
-    if (!pubkey.RecoverCompact(ss.GetHash(), vchSig)) {
-        LogPrintf("GenericVerifyInstruction(): Public Key Recovery Failed! Hash: %s\n", ss.GetHash().ToString());
-        return false;
-    }
-    CDynamicAddress address = CDynamicAddress(pubkey.GetID());
-    return address.ToString();
-}
-
 UniValue getfluidhistory(const UniValue& params, bool fHelp) {
     if (fHelp || params.size() != 0)
         throw std::runtime_error(
@@ -339,11 +316,14 @@ UniValue getfluidhistory(const UniValue& params, bool fHelp) {
             "\nResult:\n"
             "[                   (json array of object)\n"
             "  {                 (json object)\n"
-            "  \"order\"           (string) order of execution.\n"
-            "  \"operation\"       (string) The fluid operation code.\n"
-            "  \"amount\"          (string) The fluid operation amount.\n"
-            "  \"timestamp\"       (string) The fluid operation timestamp\n"
-            "  \"payment address\" (string) The fluid operation payment address\n"
+            "  \"order\"               (string) order of execution.\n"
+            "  \"operation\"           (string) The fluid operation code.\n"
+            "  \"amount\"              (string) The fluid operation amount.\n"
+            "  \"timestamp\"           (string) The fluid operation timestamp\n"
+            "  \"payment address\"     (string) The fluid operation payment address\n"
+            "  \"sovereign address 1\" (string) First sovereign signature address used\n"
+            "  \"sovereign address 2\" (string) Second sovereign signature address used\n"
+            "  \"sovereign address 3\" (string) Third sovereign signature address used\n"
             "  }, ...\n"
             "]\n"
             "\nExamples\n"
@@ -382,9 +362,9 @@ UniValue getfluidhistory(const UniValue& params, bool fHelp) {
                     obj.push_back(Pair("timestamp", strTimeStamp)); 
                 }
                 obj.push_back(Pair("payment address", vecSplitScript[2]));
-                obj.push_back(Pair("sig address1", GetAddressFromDigestSignature(vecSplitScript[3], messageTokenKey)));
-                obj.push_back(Pair("sig address2", GetAddressFromDigestSignature(vecSplitScript[4], messageTokenKey)));
-                obj.push_back(Pair("sig address3", GetAddressFromDigestSignature(vecSplitScript[5], messageTokenKey)));
+                obj.push_back(Pair("sovereign address 1", fluid.GetAddressFromDigestSignature(vecSplitScript[3], messageTokenKey).ToString()));
+                obj.push_back(Pair("sovereign address 2", fluid.GetAddressFromDigestSignature(vecSplitScript[4], messageTokenKey).ToString()));
+                obj.push_back(Pair("sovereign address 3", fluid.GetAddressFromDigestSignature(vecSplitScript[5], messageTokenKey).ToString()));
             }
             else if ((strOperationCode == "OP_REWARD_MINING" || strOperationCode == "OP_REWARD_DYNODE") && vecSplitScript.size() == 5) {
                 std::string strAmount = vecSplitScript[0];
@@ -397,9 +377,9 @@ UniValue getfluidhistory(const UniValue& params, bool fHelp) {
                 if (ParseInt64(strTimeStamp, &tokenTimeStamp)) {
                     obj.push_back(Pair("timestamp", strTimeStamp)); 
                 }
-                obj.push_back(Pair("sig address1", GetAddressFromDigestSignature(vecSplitScript[2], messageTokenKey)));
-                obj.push_back(Pair("sig address2", GetAddressFromDigestSignature(vecSplitScript[3], messageTokenKey)));
-                obj.push_back(Pair("sig address3", GetAddressFromDigestSignature(vecSplitScript[4], messageTokenKey)));
+                obj.push_back(Pair("sovereign address 1", fluid.GetAddressFromDigestSignature(vecSplitScript[2], messageTokenKey).ToString()));
+                obj.push_back(Pair("sovereign address 2", fluid.GetAddressFromDigestSignature(vecSplitScript[3], messageTokenKey).ToString()));
+                obj.push_back(Pair("sovereign address 3", fluid.GetAddressFromDigestSignature(vecSplitScript[4], messageTokenKey).ToString()));
             }
         }
         ret.push_back(obj);


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
- Displays the sovereign addresses used to sign a fluid transaction in getfluidhistory

![dynamic_getfluidhistory_show_sovereign_addresses](https://user-images.githubusercontent.com/7564876/34135836-9ea287f0-e428-11e7-8ef7-f1f85b61c169.png)
