### PR TITLE
[Miner] check for dynode syn before mining

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -491,7 +491,7 @@ void static DynamicMiner(const CChainParams& chainparams, CConnman& connman)
                 // on an obsolete chain. In regtest mode we expect to fly solo.
                 do {
                     bool fvNodesEmpty = connman.GetNodeCount(CConnman::CONNECTIONS_ALL) == 0;
-                    if (!fvNodesEmpty && !IsInitialBlockDownload())
+                    if (!fvNodesEmpty && !IsInitialBlockDownload() && dynodeSync.IsSynced() && dynodeSync.IsBlockchainSynced())
                         break;
                     MilliSleep(1000);
                 } while (true);


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
Prevents the miner from starting until all Dynode data is fully synchronized.
#### Was this PR tested and how? (If testing is not needed, please explain why)
Yes, using Ubuntu 16.04.
#### Does this PR resolve an open issue (reference issue #)?
No.