### PR TITLE
Adds clear button for hash rate graph

### DIFF
--- a/src/qt/forms/miningpage.ui
+++ b/src/qt/forms/miningpage.ui
@@ -201,7 +201,7 @@ border-radius: 4px;
      <item>
       <widget class="QCheckBox" name="checkBoxShowGraph">
        <property name="text">
-        <string>Show Hash Meter</string>
+        <string>Show Hash Meter Graph</string>
        </property>
       </widget>
      </item>
@@ -347,6 +347,13 @@ border-radius: 4px;
        </property>
        <property name="text">
         <string>5 m</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButtonClearData">
+       <property name="text">
+        <string>Clear</string>
        </property>
       </widget>
      </item>

--- a/src/qt/hashrategraphwidget.cpp
+++ b/src/qt/hashrategraphwidget.cpp
@@ -151,14 +151,11 @@ void HashRateGraphWidget::UpdateSampleTime(SampleTime time)
 void HashRateGraphWidget::StopHashMeter()
 {
     fPlotHashRate = false;
-    clear();
     update();
 }
 
 void HashRateGraphWidget::StartHashMeter()
 {
     fPlotHashRate = true;
-    clear();
     update();
 }
-

--- a/src/qt/hashrategraphwidget.h
+++ b/src/qt/hashrategraphwidget.h
@@ -44,14 +44,14 @@ public Q_SLOTS:
     void StopHashMeter();
     void StartHashMeter();
     void UpdateSampleTime(SampleTime time);
+    void clear();
 
 private:
     void timerEvent(QTimerEvent *event);
     void updateHashRateGraph();
     void initGraph(QPainter& painter);
     void drawHashRate(QPainter& painter);
-    void clear();
-
+    
     unsigned int iDesiredSamples;
     int64_t iMaxHashRate;
     QQueue<int64_t> vSampleHashRate;

--- a/src/qt/miningpage.cpp
+++ b/src/qt/miningpage.cpp
@@ -51,7 +51,9 @@ MiningPage::MiningPage(const PlatformStyle *platformStyle, QWidget *parent) :
     connect(ui->sliderCores, SIGNAL(valueChanged(int)), this, SLOT(changeNumberOfCores(int)));
     connect(ui->sliderGraphSampleTime, SIGNAL(valueChanged(int)), this, SLOT(changeSampleTime(int)));
     connect(ui->pushSwitchMining, SIGNAL(clicked()), this, SLOT(switchMining()));
+    connect(ui->pushButtonClearData, SIGNAL(clicked()), this, SLOT(clearHashRateData()));
     connect(ui->checkBoxShowGraph, SIGNAL(stateChanged(int)), this, SLOT(showHashRate(int)));
+    //
     ui->minerHashRateWidget->graphType = HashRateGraphWidget::GraphType::MINER_HASHRATE;
     ui->minerHashRateWidget->UpdateSampleTime(HashRateGraphWidget::SampleTime::FIVE_MINUTES);
     
@@ -174,10 +176,12 @@ void MiningPage::showHashMeterControls(bool show)
     if (show == false) {
         ui->sliderGraphSampleTime->setVisible(false);
         ui->labelGraphSampleSize->setVisible(false);
+        ui->pushButtonClearData->setVisible(false);
     }
     else {
         ui->sliderGraphSampleTime->setVisible(true);
         ui->labelGraphSampleSize->setVisible(true);
+        ui->pushButtonClearData->setVisible(true);
     }
 }
 
@@ -215,4 +219,9 @@ void MiningPage::changeSampleTime(int i)
         ui->minerHashRateWidget->UpdateSampleTime(HashRateGraphWidget::SampleTime::ONE_DAY);
         ui->labelGraphSampleSize->setText(QString("1 day"));
     }
+}
+
+void MiningPage::clearHashRateData()
+{
+    ui->minerHashRateWidget->clear();
 }

--- a/src/qt/miningpage.h
+++ b/src/qt/miningpage.h
@@ -47,7 +47,7 @@ private Q_SLOTS:
     void switchMining();
     void showHashRate(int i);
     void changeSampleTime(int i);
-
+    void clearHashRateData();
 };
 
 #endif // MININGPAGE_H


### PR DESCRIPTION
- Do not clear hash rate stats when start and stop miner or by clicking the show check box
- Added `Graph` to `Show Hash Rate Meter` check box label

![dynamic-miner-graph_with-clear-button](https://user-images.githubusercontent.com/38220138/39165461-2f1db776-474a-11e8-8af0-79a9d9e812d7.png)
