### PR TITLE
Truncate hash rate sample queue when too large

### DIFF
--- a/src/qt/hashrategraphwidget.cpp
+++ b/src/qt/hashrategraphwidget.cpp
@@ -19,6 +19,7 @@
 #define XMARGIN                     10
 #define YMARGIN                     10
 #define GRID_HEIGHT                 30
+#define MAX_SAMPLES                 60 * 60 * 24 // 24 hours
 
 HashRateGraphWidget::HashRateGraphWidget(QWidget *parent) :
     QWidget(parent),
@@ -93,6 +94,13 @@ void HashRateGraphWidget::paintEvent(QPaintEvent *)
     drawHashRate(painter);
 }
 
+void HashRateGraphWidget::truncateSampleQueue()
+{
+    while(vSampleHashRate.size() > MAX_SAMPLES) {
+        vSampleHashRate.pop_back();
+    }
+}
+
 void HashRateGraphWidget::updateHashRateGraph()
 {
     int64_t iCurrentHashRate = 0;
@@ -104,6 +112,11 @@ void HashRateGraphWidget::updateHashRateGraph()
     }
     
     vSampleHashRate.push_front(iCurrentHashRate);
+    
+    if (vSampleHashRate.size() > MAX_SAMPLES + DEFAULT_DESIRED_SAMPLES)
+    {
+        truncateSampleQueue();
+    }
 
     if (iMaxHashRate < iCurrentHashRate)
         iMaxHashRate = iCurrentHashRate;

--- a/src/qt/hashrategraphwidget.h
+++ b/src/qt/hashrategraphwidget.h
@@ -51,7 +51,8 @@ private:
     void updateHashRateGraph();
     void initGraph(QPainter& painter);
     void drawHashRate(QPainter& painter);
-    
+    void truncateSampleQueue();
+
     unsigned int iDesiredSamples;
     int64_t iMaxHashRate;
     QQueue<int64_t> vSampleHashRate;


### PR DESCRIPTION
- vSampleHashRate member variable was allowed to grow without any checks
- prevents a slow memory leak