### PR TITLE
[Dynode] Remove lock in ReadBlockFromDisk

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1260,13 +1260,7 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus:
 
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
 {
-    CDiskBlockPos blockPos;
-    {
-        LOCK(cs_main);
-        blockPos = pindex->GetBlockPos();
-    }
-
-    if (!ReadBlockFromDisk(block, blockPos, consensusParams))
+    if (!ReadBlockFromDisk(block, pindex->GetBlockPos(), consensusParams))
         return false;
     if (block.GetHash() != pindex->GetBlockHash())
         return error("ReadBlockFromDisk(CBlock&, CBlockIndex*): GetHash() doesn't match index for %s at %s",


### PR DESCRIPTION
### What is the purpose of this pull request (PR)?
Prevents wallet freezing when running RPC: `dynode current `and `dynode winner`

Fixes issue #148 ("RPC Error with dynode winner and current")


