### PR TITLE
Increases OP_RETURN relay size for larger BDAP entries

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1127,7 +1127,8 @@ bool AppInitParameterInteraction()
 
     fIsBareMultisigStd = GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
     fAcceptDatacarrier = GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);
-    nMaxDatacarrierBytes = GetArg("-datacarriersize", nMaxDatacarrierBytes);
+    ForceSetArg("-datacarriersize", nMaxDatacarrierBytes);
+    //LogPrintf("nMaxDatacarrierBytes=%u \n", nMaxDatacarrierBytes);
 
     fAlerts = GetBoolArg("-alerts", DEFAULT_ALERTS);
 

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -27,7 +27,7 @@ public:
     CScriptID(const uint160& in) : uint160(in) {}
 };
 
-static const unsigned int MAX_OP_RETURN_RELAY = 83; //! bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
+static const unsigned int MAX_OP_RETURN_RELAY = 2051; //! bytes (+1 for OP_RETURN, +2 for the pushdata opcodes, +2048 for BDAP data)
 extern bool fAcceptDatacarrier;
 extern unsigned nMaxDatacarrierBytes;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -486,6 +486,12 @@ void ForceSetArg(const std::string& strArg, const std::string& strValue)
     mapArgs[strArg] = strValue;
 }
 
+void ForceSetArg(const std::string& strArg, const int64_t& nValue)
+{
+    LOCK(cs_args);
+    mapArgs[strArg] = i64tostr(nValue);
+}
+
 void ForceSetMultiArgs(const std::string& strArg, const std::vector<std::string>& values)
 {
     LOCK(cs_args);

--- a/src/util.h
+++ b/src/util.h
@@ -215,6 +215,7 @@ bool SoftSetBoolArg(const std::string& strArg, bool fValue);
 
 // Forces a arg setting
 void ForceSetArg(const std::string& strArg, const std::string& strValue);
+void ForceSetArg(const std::string& strArg, const int64_t& nValue);
 void ForceSetMultiArgs(const std::string& strArg, const std::vector<std::string>& values);
 void ForceRemoveArg(const std::string& strArg);
 


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
- Increases the maximum `OP_RETURN` relay size to support BDAP entries
- Forces `nMaxDatacarrierBytes` variable to 3 (OP Code) + 2048 bytes (BDAP data) or 2,051 bytes.
- Adds ForceSetArg function to support `int64_t` argument variables