### PR TITLE
WIP, Fix issues with fluid commands and allow negative minting

### DIFF
--- a/src/fluid.cpp
+++ b/src/fluid.cpp
@@ -110,8 +110,8 @@ bool CFluid::CheckFluidOperationScript(const CScript& fluidScriptPubKey, const i
             strAmount = vecSplitScript[0];
             CAmount fluidAmount;
             if (ParseFixedPoint(strAmount, 8, &fluidAmount)) {
-                if (fluidAmount < 0) {
-                    errorMessage = "CheckFluidOperationScript fluid amount is less than zero: " + strAmount;
+                if ((strOperationCode == "OP_REWARD_MINING" || strOperationCode == "OP_REWARD_DYNODE") && fluidAmount < 0) {
+                    errorMessage = "CheckFluidOperationScript fluid reward amount is less than zero: " + strAmount;
                     return false;
                 }
                 else if (strOperationCode == "OP_MINT" && (fluidAmount > FLUID_MAX_FOR_MINT)) {

--- a/src/rpcfluid.cpp
+++ b/src/rpcfluid.cpp
@@ -298,13 +298,14 @@ UniValue getfluidhistoryraw(const JSONRPCRequest& request)
     CFluidEntry fluidIndex = pindex->fluidParams;
     std::vector<std::string> transactionRecord = fluidIndex.fluidHistory;
 
-    UniValue obj(UniValue::VOBJ);
-
-    BOOST_FOREACH(const std::string& existingRecord, transactionRecord) {
+    UniValue ret(UniValue::VARR);
+    for(const std::string& existingRecord : transactionRecord) {
+        UniValue obj(UniValue::VOBJ);
         obj.push_back(Pair("fluid command", existingRecord));
+        ret.push_back(obj);
     }
 
-    return obj;
+    return ret;
 }
 
 UniValue getfluidhistory(const JSONRPCRequest& request)

--- a/src/rpcfluid.cpp
+++ b/src/rpcfluid.cpp
@@ -410,13 +410,14 @@ UniValue getfluidsovereigns(const JSONRPCRequest& request)
 
     std::vector<std::string> sovereignLogs = fluidIndex.fluidSovereigns;
 
-    UniValue obj(UniValue::VOBJ);
-
+    UniValue ret(UniValue::VARR);
     for (const std::string& sovereign : sovereignLogs) {
+        UniValue obj(UniValue::VOBJ);
         obj.push_back(Pair("sovereign address", sovereign));
+        ret.push_back(obj);
     }
 
-    return obj;
+    return ret;
 }
 
 static const CRPCCommand commands[] =


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
- fix `getfluidhistoryraw` RPC command to return the full history, not just one record.
- fix `getfluidsovereigns` RPC command to return the full list of sovereign addresses.
- Allow a negative fluid minting amount by consensus.  Still restrict negative miner and Dynode rewards.
#### Was this PR tested and how? (If testing is not needed, please explain why)
The commands were tested using Ubuntu 16.04.  The consensus change still needs testing on testnet.
#### Does this PR resolve an open issue (reference issue #)?
Yes, issue #156