### PR TITLE
[Fluid] Fix segfault when running reindex

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3383,9 +3383,11 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const CB
 
     // Check that all transactions are finalized
     for (const CTransaction& tx : block.vtx) {
-        if (!fluid.CheckTransactionToBlock(tx, pindexPrev->GetBlockHeader()))
-            return state.DoS(10, error("%s: contains an invalid fluid transaction", __func__), REJECT_INVALID, "invalid-fluid-txns");
-
+        if (pindexPrev != nullptr) {
+            if (!fluid.CheckTransactionToBlock(tx, pindexPrev->GetBlockHeader()))
+                return state.DoS(10, error("%s: contains an invalid fluid transaction", __func__), REJECT_INVALID, "invalid-fluid-txns");
+        }
+        
         if (!IsFinalTx(tx, nHeight, nLockTimeCutoff)) {
             return state.DoS(10, error("%s: contains a non-final transaction", __func__), REJECT_INVALID, "bad-txns-nonfinal");
         }


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
Fixes an existing bug that caused the wallet to segfault after running reindex.
Bug caused by using a null pointer in `ContextualCheckBlock`
