### PR TITLE
Revert max OP_RETURN relay size to 83 bytes

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -27,7 +27,7 @@ public:
     CScriptID(const uint160& in) : uint160(in) {}
 };
 
-static const unsigned int MAX_OP_RETURN_RELAY = 2051; //! bytes (+1 for OP_RETURN, +2 for the pushdata opcodes, +2048 for BDAP data)
+static const unsigned int MAX_OP_RETURN_RELAY = 83; //! bytes (+1 for OP_RETURN, +2 for the push data opcodes)
 extern bool fAcceptDatacarrier;
 extern unsigned nMaxDatacarrierBytes;
 


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
Reverts max OP_RETURN relay size back to 83 bytes.  `MAX_OP_RETURN_RELAY` was increased for BDAP transactions but was not done correctly so it affected non-BDAP txs.
