### PR TITLE
 M-of-N-like sporks

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -217,7 +217,8 @@ public:
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 60 * 60; // fulfilled requests expire in 1 hour
 
-        strSporkAddress = "DDDax6fjzoCqHj9nwTgNdAQsucFBJUJ3Jk";
+        vSporkAddresses = {"DDDax6fjzoCqHj9nwTgNdAQsucFBJUJ3Jk"};
+        nMinSporkKeys = 1; 
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -354,7 +355,8 @@ public:
         nPoolMaxTransactions = 3;
         nFulfilledRequestExpireTime = 5 * 60; // fulfilled requests expire in 5 minutes
         // To import spork key: importprivkey 6Jjb9DG1cr71VWiwxg97zVEyZUBhFzzGhqE7GY9DrbYYM6gVgxS
-        strSporkAddress = "DGjj2YB4c988rpgVQbhkLnwthRDbmZF2ie"; // Must have this converted to an address "043d9e8440ea8fe66b0c2639f0a0931c9d7c41132ec9ee04cdf5d9e88ada2c2df52d93a0c1983958d3aea56df9fb3d1a61ca4eb6f72c27456fc313be80cdc70032";
+        vSporkAddresses = {"DGjj2YB4c988rpgVQbhkLnwthRDbmZF2ie"}; // Must have this converted to an address "043d9e8440ea8fe66b0c2639f0a0931c9d7c41132ec9ee04cdf5d9e88ada2c2df52d93a0c1983958d3aea56df9fb3d1a61ca4eb6f72c27456fc313be80cdc70032";
+        nMinSporkKeys = 1; 
 
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
@@ -464,8 +466,9 @@ public:
 
         nFulfilledRequestExpireTime = 5 * 60; // fulfilled requests expire in 5 minutes
         
-        strSporkAddress = "D5uFBBHBe11nmYPmSNNTC1iR6V6bPkhJwe";
-        
+        vSporkAddresses = {"D5uFBBHBe11nmYPmSNNTC1iR6V6bPkhJwe"};
+        nMinSporkKeys = 1; 
+
         checkpointData = (CCheckpointData) {
             boost::assign::map_list_of
             (  0, uint256S("0x000ab751d858e116043e741d097311f2382e600c219483cfda8f25c7f369cc2c"))

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -89,7 +89,8 @@ public:
     const ChainTxData& TxData() const { return chainTxData; }
     int PoolMaxTransactions() const { return nPoolMaxTransactions; }
     int FulfilledRequestExpireTime() const { return nFulfilledRequestExpireTime; }
-    const std::string& SporkAddress() const { return strSporkAddress; }
+    const std::vector<std::string>& SporkAddresses() const { return vSporkAddresses; }
+    int MinSporkKeys() const { return nMinSporkKeys; }
 protected:
     CChainParams() {}
 
@@ -117,7 +118,8 @@ protected:
     ChainTxData chainTxData;
     int nPoolMaxTransactions;
     int nFulfilledRequestExpireTime;
-    std::string strSporkAddress;
+    std::vector<std::string> vSporkAddresses;
+    int nMinSporkKeys;
     std::string strDynodePaymentsPubKey;
 };
 

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -31,6 +31,24 @@ std::map<int, int64_t> mapSporkDefaults = {
     {SPORK_14_REQUIRE_SENTINEL_FLAG,         4070908800ULL}, // OFF
 };
 
+bool CSporkManager::SporkValueIsActive(int nSporkID, int64_t &nActiveValueRet) const
+{
+    LOCK(cs);
+    if (!mapSporksActive.count(nSporkID)) return false;
+    // calc how many values we have and how many signers vote for every value
+    std::map<int64_t, int> mapValueCounts;
+    for (const auto& pair: mapSporksActive.at(nSporkID)) {
+        mapValueCounts[pair.second.nValue]++;
+        if (mapValueCounts.at(pair.second.nValue) >= nMinSporkKeys) {
+            // nMinSporkKeys is always more than the half of the max spork keys number,
+            // so there is only one such value and we can stop here
+            nActiveValueRet = pair.second.nValue;
+            return true;
+        }
+    }
+    return false;
+}
+
 void CSporkManager::Clear()
 {
     LOCK(cs);
@@ -43,27 +61,45 @@ void CSporkManager::Clear()
 void CSporkManager::CheckAndRemove()
 {
     LOCK(cs);
-    bool fSporkAddressIsSet = !sporkPubKeyID.IsNull();
+    bool fSporkAddressIsSet = !setSporkPubKeyIDs.empty(); 
     assert(fSporkAddressIsSet);
     auto itActive = mapSporksActive.begin();
     while (itActive != mapSporksActive.end()) {
-        if (!itActive->second.CheckSignature(sporkPubKeyID, false)) {
-            if (!itActive->second.CheckSignature(sporkPubKeyID, true)) {
-                mapSporksByHash.erase(itActive->second.GetHash());
-                mapSporksActive.erase(itActive++);
+        auto itSignerPair = itActive->second.begin(); 
+        while (itSignerPair != itActive->second.end()) { 
+            if (setSporkPubKeyIDs.find(itSignerPair->first) == setSporkPubKeyIDs.end()) {
+                mapSporksByHash.erase(itSignerPair->second.GetHash());
                 continue;
             }
+            if (!itSignerPair->second.CheckSignature(itSignerPair->first, false)) {
+                if (!itSignerPair->second.CheckSignature(itSignerPair->first, true)) {
+                    mapSporksByHash.erase(itSignerPair->second.GetHash());
+                    itActive->second.erase(itSignerPair++);
+                    continue;
+                }
+            }
+            ++itSignerPair;
+        }
+        if (itActive->second.empty()) {
+            mapSporksActive.erase(itActive++);
+            continue;
         }
         ++itActive;
     }
+
     auto itByHash = mapSporksByHash.begin();
     while (itByHash != mapSporksByHash.end()) {
-        if (!itByHash->second.CheckSignature(sporkPubKeyID, false)) {
-            if (!itByHash->second.CheckSignature(sporkPubKeyID, true)) {
-                mapSporksActive.erase(itByHash->second.nSporkID);
-                mapSporksByHash.erase(itByHash++);
-                continue;
+        bool found = false; 
+        for (const auto& signer: setSporkPubKeyIDs) { 
+            if (itByHash->second.CheckSignature(signer, false) || 
+                itByHash->second.CheckSignature(signer, true)) { 
+                 found = true; 
+                 break; 
             }
+        }
+        if (!found) {
+            mapSporksByHash.erase(itByHash++);
+            continue;
         }
         ++itByHash;
     }
@@ -87,41 +123,60 @@ void CSporkManager::ProcessSpork(CNode* pfrom, const std::string& strCommand, CD
             if(!chainActive.Tip()) return;
             strLogMsg = strprintf("SPORK -- hash: %s id: %d value: %10d bestHeight: %d peer=%d", hash.ToString(), spork.nSporkID, spork.nValue, chainActive.Height(), pfrom->id);
         }
-        { 
-            LOCK(cs); // make sure to not lock this together with cs_main 
-            if (mapSporksActive.count(spork.nSporkID)) {
-                if (mapSporksActive[spork.nSporkID].nTimeSigned >= spork.nTimeSigned) {
-                LogPrint("spork", "%s seen\n", strLogMsg);
-            } else {
-                LogPrintf("%s updated\n", strLogMsg);
-            }
+
+        CKeyID keyIDSigner;
+        bool fSpork6IsActive = IsSporkActive(SPORK_6_NEW_SIGS);
+        if (!spork.GetSignerKeyID(keyIDSigner, fSpork6IsActive)
+                                 || !setSporkPubKeyIDs.count(keyIDSigner)) {
+            // Note: unlike for other messages we have to check for new format even with SPORK_6_NEW_SIGS
+            // inactive because SPORK_6_NEW_SIGS default is OFF and it is not the first spork to sync
+            // (and even if it would, spork order can't be guaranteed anyway).
+            if (!spork.GetSignerKeyID(keyIDSigner, !fSpork6IsActive)
+                                     || !setSporkPubKeyIDs.count(keyIDSigner)) {
+                LOCK(cs_main);
+                LogPrintf("CSporkManager::ProcessSpork -- ERROR: invalid signature\n");
+                Misbehaving(pfrom->GetId(), 100);
                 return;
+            }
+        }
+
+        { 
+            LOCK(cs); // make sure to not lock this together with cs_main
+            if (mapSporksActive.count(spork.nSporkID)) {
+                if (mapSporksActive[spork.nSporkID].count(keyIDSigner)) {
+                    if (mapSporksActive[spork.nSporkID][keyIDSigner].nTimeSigned >= spork.nTimeSigned) {
+                        LogPrint("spork", "%s seen\n", strLogMsg);
+                        return;
+                    } else {
+                        LogPrintf("%s updated\n", strLogMsg);
+                    }
+                } else {
+                    LogPrintf("%s new signer\n", strLogMsg);
+                }
             } else {
                 LogPrintf("%s new\n", strLogMsg);
             }
         }
 
-        if(!spork.CheckSignature(sporkPubKeyID, IsSporkActive(SPORK_6_NEW_SIGS))) { 
-            LOCK(cs_main);
-            LogPrintf("CSporkManager::ProcessSpork -- invalid signature\n");
-            Misbehaving(pfrom->GetId(), 100);
-            return;
-        }
-
         { 
             LOCK(cs); // make sure to not lock this together with cs_main 
             mapSporksByHash[hash] = spork; 
-            mapSporksActive[spork.nSporkID] = spork;
+            mapSporksActive[spork.nSporkID][keyIDSigner] = spork; 
         }
         spork.Relay(connman);
 
         //does a task if needed
-        ExecuteSpork(spork.nSporkID, spork.nValue);
+        int64_t nActiveValue = 0;
+        if (SporkValueIsActive(spork.nSporkID, nActiveValue)) {
+            ExecuteSpork(spork.nSporkID, nActiveValue);
+        }
 
     } else if (strCommand == NetMsgType::GETSPORKS) {
         LOCK(cs); // make sure to not lock this together with cs_main 
         for (const auto& pair : mapSporksActive) {
-            connman.PushMessage(pfrom, CNetMsgMaker(pfrom->GetSendVersion()).Make(NetMsgType::SPORK, pair.second));
+            for (const auto& signerSporkPair: pair.second) {
+                connman.PushMessage(pfrom, CNetMsgMaker(pfrom->GetSendVersion()).Make(NetMsgType::SPORK, signerSporkPair.second));
+            }
         }
     }
 
@@ -159,11 +214,17 @@ bool CSporkManager::UpdateSpork(int nSporkID, int64_t nValue, CConnman& connman)
 {
     CSporkMessage spork = CSporkMessage(nSporkID, nValue, GetAdjustedTime());
 
-    if(spork.Sign(sporkPrivKey, IsSporkActive(SPORK_6_NEW_SIGS))) { 
+    bool fSpork6IsActive = IsSporkActive(SPORK_6_NEW_SIGS);
+    if(spork.Sign(sporkPrivKey, fSpork6IsActive)) {
+        CKeyID keyIDSigner;
+        if (!spork.GetSignerKeyID(keyIDSigner, fSpork6IsActive) || !setSporkPubKeyIDs.count(keyIDSigner)) {
+            LogPrintf("CSporkManager::UpdateSpork: failed to find keyid for private key\n");
+            return false;
+        }
         spork.Relay(connman);
         LOCK(cs); 
         mapSporksByHash[spork.GetHash()] = spork; 
-        mapSporksActive[nSporkID] = spork;
+        mapSporksActive[nSporkID][keyIDSigner] = spork; 
         return true;
     }
 
@@ -174,26 +235,27 @@ bool CSporkManager::UpdateSpork(int nSporkID, int64_t nValue, CConnman& connman)
 bool CSporkManager::IsSporkActive(int nSporkID)
 {
     LOCK(cs); 
-    int64_t r = -1;
+    int64_t nSporkValue = -1; 
 
-    if(mapSporksActive.count(nSporkID)){
-        r = mapSporksActive[nSporkID].nValue;
-    } else if (mapSporkDefaults.count(nSporkID)) {
-        r = mapSporkDefaults[nSporkID];
-    } else {
-        LogPrint("spork", "CSporkManager::IsSporkActive -- Unknown Spork ID %d\n", nSporkID);
-        r = 4070908800ULL; // 2099-1-1 i.e. off by default
+     if (SporkValueIsActive(nSporkID, nSporkValue)) { 
+         return nSporkValue < GetAdjustedTime(); 
     }
 
-    return r < GetAdjustedTime();
+    if (mapSporkDefaults.count(nSporkID)) {
+        return  mapSporkDefaults[nSporkID] < GetAdjustedTime();
+    }
+    LogPrint("spork", "CSporkManager::IsSporkActive -- Unknown Spork ID %d\n", nSporkID);
+    return false;
 }
 
 // grab the value of the spork on the network, or the default
 int64_t CSporkManager::GetSporkValue(int nSporkID)
 {
     LOCK(cs); 
-    if (mapSporksActive.count(nSporkID))
-        return mapSporksActive[nSporkID].nValue;
+    int64_t nSporkValue = -1;
+    if (SporkValueIsActive(nSporkID, nSporkValue)) {
+        return nSporkValue;
+    }
 
     if (mapSporkDefaults.count(nSporkID)) {
         return mapSporkDefaults[nSporkID];
@@ -251,10 +313,23 @@ bool CSporkManager::GetSporkByHash(const uint256& hash, CSporkMessage &sporkRet)
 bool CSporkManager::SetSporkAddress(const std::string& strAddress) {
     LOCK(cs); 
     CDynamicAddress address(strAddress);
-    if (!address.IsValid() || !address.GetKeyID(sporkPubKeyID)) {
+    CKeyID keyid;
+    if (!address.IsValid() || !address.GetKeyID(keyid)) {
         LogPrintf("CSporkManager::SetSporkAddress -- Failed to parse spork address\n");
         return false;
     }
+    setSporkPubKeyIDs.insert(keyid);
+    return true;
+}
+
+bool CSporkManager::SetMinSporkKeys(int minSporkKeys)
+{
+    int maxKeysNumber = setSporkPubKeyIDs.size();
+    if ((minSporkKeys <= maxKeysNumber / 2) || (minSporkKeys > maxKeysNumber)) {
+        LogPrintf("CSporkManager::SetMinSporkKeys -- Invalid min spork signers number: %d\n", minSporkKeys);
+        return false;
+    }
+    nMinSporkKeys = minSporkKeys;
     return true;
 }
 
@@ -267,8 +342,8 @@ bool CSporkManager::SetPrivKey(const std::string& strPrivKey)
         return false;
     }
 
-    if (pubKey.GetID() != sporkPubKeyID) {
-        LogPrintf("CSporkManager::SetPrivKey -- New private key does not belong to spork address\n");
+     if (setSporkPubKeyIDs.find(pubKey.GetID()) == setSporkPubKeyIDs.end()) { 
+        LogPrintf("CSporkManager::SetPrivKey -- New private key does not belong to spork addresses\n"); 
         return false;
     }
 
@@ -299,7 +374,11 @@ uint256 CSporkMessage::GetHash() const
 
 uint256 CSporkMessage::GetSignatureHash() const
 {
-    return GetHash();
+    CHashWriter s(SER_GETHASH, 0);
+    s << nSporkID;
+    s << nValue;
+    s << nTimeSigned;
+    return s.GetHash();
 }
 
 bool CSporkMessage::Sign(const CKey& key, bool fSporkSixActive) 
@@ -369,6 +448,26 @@ bool CSporkMessage::CheckSignature(const CKeyID& pubKeyId, bool fSporkSixActive)
         }
     }
 
+    return true;
+}
+
+bool CSporkMessage::GetSignerKeyID(CKeyID &retKeyidSporkSigner, bool fSporkSixActive)
+{
+    CPubKey pubkeyFromSig;
+    if (fSporkSixActive) {
+        if (!pubkeyFromSig.RecoverCompact(GetSignatureHash(), vchSig)) {
+            return false;
+        }
+    } else {
+        std::string strMessage = std::to_string(nSporkID) + std::to_string(nValue) + std::to_string(nTimeSigned);
+        CHashWriter ss(SER_GETHASH, 0);
+        ss << strMessageMagic;
+        ss << strMessage;
+        if (!pubkeyFromSig.RecoverCompact(ss.GetHash(), vchSig)) {
+            return false;
+        }
+    }
+    retKeyidSporkSigner = pubkeyFromSig.GetID();
     return true;
 }
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -70,16 +70,15 @@ public:
         READWRITE(nSporkID);
         READWRITE(nValue);
         READWRITE(nTimeSigned);
-        if (!(s.GetType() & SER_GETHASH)) {
-            READWRITE(vchSig);
-        }
+        READWRITE(vchSig); 
     }
 
     uint256 GetHash() const;
     uint256 GetSignatureHash() const;
 
     bool Sign(const CKey& key, bool fSporkSixActive); 
-    bool CheckSignature(const CKeyID& pubKeyId, bool fSporkSixActive) const; 
+    bool CheckSignature(const CKeyID& pubKeyId, bool fSporkSixActive) const;
+    bool GetSignerKeyID(CKeyID& retKeyidSporkSigner, bool fSporkSixActive);
     void Relay(CConnman& connman);
 };
 
@@ -91,11 +90,13 @@ private:
 
     mutable CCriticalSection cs; 
     std::map<uint256, CSporkMessage> mapSporksByHash; 
-    std::map<int, CSporkMessage> mapSporksActive;
+    std::map<int, std::map<CKeyID, CSporkMessage> > mapSporksActive;
 
-    CKeyID sporkPubKeyID;
+    std::set<CKeyID> setSporkPubKeyIDs;
+    int nMinSporkKeys;
     CKey sporkPrivKey;
 
+    bool SporkValueIsActive(int nSporkID, int64_t& nActiveValueRet) const;
 public:
 
     CSporkManager() {}
@@ -113,13 +114,15 @@ public:
             strVersion = SERIALIZATION_VERSION_STRING;
             READWRITE(strVersion);
         }
-        READWRITE(sporkPubKeyID);
+        // we don't serialize pubkey ids because pubkeys should be
+        // hardcoded or be setted with cmdline or options, should
+        // not reuse pubkeys from previous dynamicd run
         READWRITE(mapSporksByHash);
         READWRITE(mapSporksActive);
         // we don't serialize private key to prevent its leakage
     }
     void Clear();
-     void CheckAndRemove(); 
+    void CheckAndRemove(); 
 
     void ProcessSpork(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
     void ExecuteSpork(int nSporkID, int nValue);
@@ -133,6 +136,7 @@ public:
     bool GetSporkByHash(const uint256& hash, CSporkMessage &sporkRet); 
 
     bool SetSporkAddress(const std::string& strAddress);
+    bool SetMinSporkKeys(int minSporkKeys); 
     bool SetPrivKey(const std::string& strPrivKey);
 
     std::string ToString() const; 


### PR DESCRIPTION
* support set of keys to sign spork

* several addresses support in -sporkkey

* tests for multykey sporks

* command line option -minsporkkeys

* make spork active only after given number of signers

* use signature in spork hash calculation

* test for new and old spork messages interaction

* add multikeyspork.py to integration tests

* change test to have ability to distinguish default spork value

* require min spork keys number to be more than the half of the common spork keys number

* calc current spork value with majority of signers

* set test nodes time in integration test

* extract keyid from signed spork message directly

* change -sporkaddr option syntax to process several addresses

* codestyle fixes

* fix test comments

* codestyle fixes

* simplify CSporkManager::SporkValueIsActive

* Calc signature hash without signature field

* do not restore pubkey ids from cach

* Calc different keyids to check signature because not all sporks can be synced at moment

* codestyle fixes

* Fix CSporkManager::CheckAndRemove to use several keys

* codestyle fixes

* Correct processing of not actual spork6 value with GetSignerKeyID