### PR TITLE
Fixed dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
 
-    sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libcrypto++-dev libevent-dev git
+    sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libcrypto++-dev libevent-dev git automake
     
 for Ubuntu 12.04 and later or Debian 7 and later libboost-all-dev has to be installed:
 


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
Users may need to install "automake" 
Without it they may get the error:
```Can't exec "aclocal": No such file or directory .....```
when they try to run
```sudo ./autogen.sh```
#### Was this PR tested and how? (If testing is not needed, please explain why)
Attempted a raw, no script manual install on an Ubuntu 18.04 VPS with Vultr by just following the instructions. Installing automake fixed the issue. 
#### Does this PR resolve an open issue (reference issue #)?
no