### PR TITLE
Fixes to v2.4.7

### DIFF
--- a/src/bdap/rpclinking.cpp
+++ b/src/bdap/rpclinking.cpp
@@ -742,8 +742,6 @@ static UniValue DeleteLink(const JSONRPCRequest& request)
 
 UniValue link(const JSONRPCRequest& request) 
 {
-    if (!sporkManager.IsSporkActive(SPORK_30_ACTIVATE_BDAP))
-        throw std::runtime_error("BDAP_LINK_RPC_ERROR: ERRCODE: 3000 - " + _("Can not create BDAP link transactions until spork is active."));
 
     std::string strCommand;
     if (request.params.size() >= 1) {
@@ -760,6 +758,11 @@ UniValue link(const JSONRPCRequest& request)
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("link accept", "superman batman"));
     }
+    if (strCommand == "request" || strCommand == "accept" || strCommand == "delete") {
+        if (!sporkManager.IsSporkActive(SPORK_30_ACTIVATE_BDAP))
+            throw std::runtime_error("BDAP_LINK_RPC_ERROR: ERRCODE: 3000 - " + _("Can not create BDAP link transactions until spork is active."));
+    }
+
     if (strCommand == "request") {
         return SendLinkRequest(request);
     }

--- a/src/qt/bdaplinktablemodel.cpp
+++ b/src/qt/bdaplinktablemodel.cpp
@@ -6,6 +6,7 @@
 #include "bdappage.h"
 #include "guiconstants.h"
 #include "guiutil.h"
+#include "spork.h"
 #include "sync.h"
 #include "validation.h" // for cs_main
 #include "rpcregister.h"
@@ -34,6 +35,8 @@ public:
     /** Populate tableWidget_Users via RPC call */
     void refreshLinks(QTableWidget* inputtable, QLabel* statusDisplay, std::string searchRequestor = "", std::string searchRecipient = "")
     {
+        if (!sporkManager.IsSporkActive(SPORK_30_ACTIVATE_BDAP))
+            return;
 
         JSONRPCRequest jreq;
         std::vector<std::string> params;

--- a/src/version.h
+++ b/src/version.h
@@ -21,7 +21,7 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 60800;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 71100; // TODO: Change back to 70900 -- only connect to v2.3 Nodes and newer
+static const int MIN_PEER_PROTO_VERSION = 70900; // Only connect to v2.3 Nodes and newer
 
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this


### PR DESCRIPTION
- Revert minimum protocol back to 70900 (v2.3)
- Prevent error dialog warning "Can not create BDAP link transactions until spork is active."

![dynamic-bdap-spork-warning](https://user-images.githubusercontent.com/7564876/53058390-70851300-3478-11e9-8523-21a5efc6d212.png)

