### PR TITLE
BDAP v2.4.16 Updates

### DIFF
--- a/src/bdap/linkmanager.cpp
+++ b/src/bdap/linkmanager.cpp
@@ -424,6 +424,7 @@ bool CLinkManager::ProcessLink(const CLinkStorage& storage, const bool fStoreInQ
                         }
                         record.LinkID = linkID;
                         record.fRequestFromMe = fIsLinkFromMe;
+                        record.fAcceptFromMe =  (fIsLinkFromMe && fIsLinkForMe);
                         if (record.nHeightAccept > 0) {
                             record.nLinkState = 2;
                         }
@@ -588,6 +589,7 @@ bool CLinkManager::ProcessLink(const CLinkStorage& storage, const bool fStoreInQ
                             record = it->second;
                         }
                         record.LinkID = linkID;
+                        record.fRequestFromMe = (fIsLinkFromMe && fIsLinkForMe);
                         record.fAcceptFromMe = fIsLinkFromMe;
                         record.nLinkState = 2;
                         record.RequestorFullObjectPath = link.RequestorFullObjectPath;

--- a/src/bdap/linkmanager.cpp
+++ b/src/bdap/linkmanager.cpp
@@ -252,6 +252,9 @@ bool CLinkManager::ListMyCompleted(std::vector<CLink>& vchLinks)
 
 bool CLinkManager::ProcessLink(const CLinkStorage& storage, const bool fStoreInQueueOnly)
 {
+    if (!pwalletMain)
+        return false;
+
     if (fStoreInQueueOnly || pwalletMain->IsLocked()) {
         linkQueue.push(storage);
         return true;

--- a/src/dht/datachunk.h
+++ b/src/dht/datachunk.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-static constexpr unsigned int DHT_DATA_MAX_CHUNK_SIZE = 450;
+static constexpr unsigned int DHT_DATA_MAX_CHUNK_SIZE = 900;
 
 class CDataChunk
 {
@@ -18,19 +18,25 @@ public:
     uint16_t nOrdinal;
     uint16_t nPlacement;
     std::string Salt;
-    std::string Value;
+    std::vector<unsigned char> vchValue;
 
-    CDataChunk() : nOrdinal(0), nPlacement(0), Salt(""), Value("")  {}
+    CDataChunk() : nOrdinal(0), nPlacement(0), Salt("")
+    { 
+        vchValue.clear();
+    }
 
     CDataChunk(const uint16_t ordinal, const uint16_t placement, const std::string& salt, const std::string& value) : 
-                    nOrdinal(ordinal), nPlacement(placement), Salt(salt), Value(value)  {}
+                    nOrdinal(ordinal), nPlacement(placement), Salt(salt), vchValue(value.begin(), value.end()) {}
+
+    CDataChunk(const uint16_t ordinal, const uint16_t placement, const std::string& salt, const std::vector<unsigned char>& vch) : 
+                    nOrdinal(ordinal), nPlacement(placement), Salt(salt), vchValue(vch) {}
 
     inline void SetNull()
     {
         nOrdinal = 0;
         nPlacement = 0;
         Salt = "";
-        Value = "";
+        vchValue.clear();
     }
 
     ADD_SERIALIZE_METHODS;
@@ -40,11 +46,11 @@ public:
         READWRITE(nOrdinal);
         READWRITE(nPlacement);
         READWRITE(Salt);
-        READWRITE(Value);
+        READWRITE(vchValue);
     }
 
     inline friend bool operator==(const CDataChunk& a, const CDataChunk& b) {
-        return (a.nOrdinal == b.nOrdinal && a.nPlacement == b.nPlacement && a.Salt == b.Salt && a.Value == b.Value);
+        return (a.nOrdinal == b.nOrdinal && a.nPlacement == b.nPlacement && a.Salt == b.Salt && a.vchValue == b.vchValue);
     }
 
     inline friend bool operator!=(const CDataChunk& a, const CDataChunk& b) {
@@ -55,11 +61,11 @@ public:
         nOrdinal = b.nOrdinal;
         nPlacement = b.nPlacement;
         Salt = b.Salt;
-        Value = b.Value;
+        vchValue = b.vchValue;
         return *this;
     }
  
-    inline bool IsNull() const { return (nOrdinal == 0 && nPlacement == 0 && Salt == "" && Value == ""); }
+    inline bool IsNull() const { return (nOrdinal == 0 && nPlacement == 0 && Salt == "" && vchValue.size() == 0); }
 
     void Serialize(std::vector<unsigned char>& vchData);
     bool UnserializeFromData(const std::vector<unsigned char>& vchData);

--- a/src/dht/session.cpp
+++ b/src/dht/session.cpp
@@ -44,9 +44,9 @@ static bool fStarted;
 CHashTableSession* pHashTableSession;
 
 namespace DHT {
-    std::vector<std::pair<std::string, std::string>> vPutValues;
+    std::vector<std::pair<std::string, libtorrent::entry>> vPutBytes;
 
-    void put_mutable_string
+    void put_mutable_bytes
     (
         libtorrent::entry& e
         ,std::array<char, 64>& sig
@@ -54,25 +54,23 @@ namespace DHT {
         ,std::string const& salt
         ,std::array<char, 32> const& pk
         ,std::array<char, 64> const& sk
-        ,char const* str
+        ,libtorrent::entry const& entry
         ,std::int64_t const& iSeq
     )
     {
         using dht::sign_mutable_item;
-        if (str != NULL) {
-            e = std::string(str);
-            std::vector<char> buf;
-            bencode(std::back_inserter(buf), e);
-            dht::signature sign;
-            seq = iSeq;
-            LogPrintf("%s --\nSalt = %s\nValue = %s\nSequence = %li\n", __func__, salt, std::string(str), seq);
-            sign = sign_mutable_item(buf, salt, dht::sequence_number(seq)
-                , dht::public_key(pk.data())
-                , dht::secret_key(sk.data()));
-            sig = sign.bytes;
-        }
+        e = entry;
+        std::vector<char> bufSign;
+        bencode(std::back_inserter(bufSign), e);
+        dht::signature sign;
+        seq = iSeq;
+        LogPrintf("%s --\nSalt = %s\nSequence = %d, e = %s\n", __func__, salt, seq, e.to_string());
+        sign = sign_mutable_item(bufSign, salt, dht::sequence_number(seq)
+            , dht::public_key(pk.data())
+            , dht::secret_key(sk.data()));
+        sig = sign.bytes;
     }
-}   
+}
 
 bool Bootstrap()
 {
@@ -293,22 +291,19 @@ bool CHashTableSession::SubmitPut(const std::array<char, 32> public_key, const s
     }
     mPutCommands[recordKey] = GetTime();
     vDataEntries.push_back(record);
-    DHT::vPutValues.clear();
-    std::vector<std::vector<unsigned char>> vPubKeys;
-    std::string strSalt = record.GetHeader().Salt;
-    DHT::vPutValues.push_back(std::make_pair(strSalt, record.HeaderHex));
-
-    LogPrint("dht", "CHashTableSession::%s -- PutMutableData started, Salt = %s, Value = %s, lastSequence = %li, vPutValues size = %u\n", __func__, 
-                                                                strSalt, record.Value(), lastSequence, DHT::vPutValues.size());
-    for(const CDataChunk& chunk: record.GetChunks()) {
-        DHT::vPutValues.push_back(std::make_pair(chunk.Salt, chunk.Value));
+    std::string strHeaderSalt = record.GetHeader().Salt;
+    DHT::vPutBytes.clear();
+    libtorrent::entry entryHeaderHex(record.HeaderHex);
+    DHT::vPutBytes.push_back(std::make_pair(strHeaderSalt, entryHeaderHex));
+    for (const CDataChunk& chunk : record.GetChunks()) {
+        libtorrent::entry entryChunkRaw(stringFromVch(chunk.vchValue));
+        DHT::vPutBytes.push_back(std::make_pair(chunk.Salt, entryChunkRaw));
+        LogPrint("dht", "CHashTableSession::%s -- chunk salt: %s, value: %s\n", __func__, chunk.Salt, entryChunkRaw.to_string());
     }
 
-    for(const std::pair<std::string, std::string>& pair: DHT::vPutValues) {
-        Session->dht_put_item(public_key, std::bind(&DHT::put_mutable_string, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, 
-                                public_key, private_key, pair.second.c_str(), lastSequence), pair.first);
-
-        LogPrint("dht", "CHashTableSession::%s -- salt: %s, value: %s\n", __func__, pair.first, pair.second);
+    for (const std::pair<std::string, libtorrent::entry>& pair : DHT::vPutBytes) {
+        Session->dht_put_item(public_key, std::bind(&DHT::put_mutable_bytes, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, 
+                                public_key, private_key, pair.second, lastSequence), pair.first);
     }
     nPutRecords++;
     if (nPutRecords % 32 == 0)

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -37,7 +37,7 @@ class CHashTableSession {
 public:
     CDataRecordBuffer vDataEntries;
     libtorrent::session* Session = NULL;
-    std::map<HashRecordKey, uint32_t> mPutCommands;
+    std::map<HashRecordKey, int64_t> mPutCommands;
     std::string strPutErrorMessage;
     uint64_t nPutRecords;
 
@@ -54,7 +54,7 @@ public:
 
 private:
     void CleanUpPutCommandMap();
-    uint32_t GetLastPutDate(const HashRecordKey& recordKey);
+    int64_t GetLastPutDate(const HashRecordKey& recordKey);
     bool GetDataFromMap(const std::array<char, 32>& public_key, const std::string& recordSalt, CMutableGetEvent& event);
 
 };

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -29,6 +29,7 @@ static constexpr int DHT_BOOTSTRAP_ALERT_TYPE_CODE = 62;
 static constexpr int DHT_STATS_ALERT_TYPE_CODE = 83;
 static constexpr int DHT_ERROR_ALERT_TYPE_CODE = 73;
 static constexpr int64_t DHT_RECORD_LOCK_SECONDS = 16;
+static constexpr uint32_t DHT_KEEP_PUT_BUFFER_SECONDS = 300;
 
 typedef std::pair<std::array<char, 32>, std::string> HashRecordKey; // public key and salt pair
 
@@ -42,7 +43,7 @@ public:
 
     CHashTableSession() : vDataEntries(CDataRecordBuffer(32)), strPutErrorMessage(""), nPutRecords(0) {};
 
-    bool SubmitPut(const std::array<char, 32> public_key, const std::array<char, 64> private_key, const int64_t lastSequence, const CDataRecord record);
+    bool SubmitPut(const std::array<char, 32> public_key, const std::array<char, 64> private_key, const int64_t lastSequence, CDataRecord& record);
 
     bool SubmitGet(const std::array<char, 32>& public_key, const std::string& recordSalt);
     bool SubmitGet(const std::array<char, 32>& public_key, const std::string& recordSalt, const int64_t& timeout, 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -615,7 +615,8 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
 
             CLinkStorage storage;
             ssValue >> storage;
-
+            if (!pwalletMain)
+                pwalletMain = pwallet;
             ProcessLink(storage, true);
         } else if (strType == "linkid") {
             uint256 SubjectID;


### PR DESCRIPTION

-  Use bytes for DHT instead of strings for put and get operations
-  Persist DHT put buffer so data doesn't get overwritten
-  Make sure wallet is not null before processing links in manager
-  Update VGP library sub-module with verify ciphertext checks
-  Fix link status when to and from your wallet
-  Return an error in putbdapdata when record is locked. 