### PR TITLE
BDAP v2.4.17 Fixes

### DIFF
--- a/src/bdap/domainentry.cpp
+++ b/src/bdap/domainentry.cpp
@@ -277,7 +277,7 @@ std::string CDomainEntry::GenerateOID() const
         {
             strHeight = std::to_string(nHeight);
         }
-        if (!txHash.IsNull())
+        if (!txHash.IsNull() && !IsInitialBlockDownload())
         {
             CTransactionRef txRef;
             uint256 hashBlock;

--- a/src/bdap/domainentrydb.h
+++ b/src/bdap/domainentrydb.h
@@ -44,11 +44,11 @@ bool GetDomainEntryPubKey(const std::vector<unsigned char>& vchPubKey, CDomainEn
 bool CheckDomainEntryDB();
 bool FlushLevelDB();
 void CleanupLevelDB(int& nRemoved);
-bool CheckNewDomainEntryTxInputs(const CDomainEntry& entry, const CScript& scriptOp, const vchCharString& vvchOpParameters,
+bool CheckNewDomainEntryTxInputs(const CDomainEntry& entry, const CScript& scriptOp, const vchCharString& vvchOpParameters, const uint256& txHash,
                                std::string& errorMessage, bool fJustCheck);
 bool CheckDeleteDomainEntryTxInputs(const CTransaction& tx, const CDomainEntry& entry, const CScript& scriptOp, const vchCharString& vvchOpParameters,
                                   std::string& errorMessage, bool fJustCheck);
-bool CheckUpdateDomainEntryTxInputs(const CTransaction& tx, const CDomainEntry& entry, const CScript& scriptOp, const vchCharString& vvchOpParameters,
+bool CheckUpdateDomainEntryTxInputs(const CTransaction& tx, const CDomainEntry& entry, const CScript& scriptOp, const vchCharString& vvchOpParameters, const uint256& txHash,
                                   std::string& errorMessage, bool fJustCheck);
 bool CheckMoveDomainEntryTxInputs(const CTransaction& tx, const CDomainEntry& entry, const CScript& scriptOp, const vchCharString& vvchOpParameters,
                                 std::string& errorMessage, bool fJustCheck);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3706,7 +3706,10 @@ static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state
 
     // TODO : ENABLE BLOCK CACHE IN SPECIFIC CASES
     if (hash != chainparams.GetConsensus().hashGenesisBlock) {
-        if (miSelf != mapBlockIndex.end()) {
+        if (miSelf != mapBlockIndex.end() && !miSelf->second) {
+            mapBlockIndex.erase(hash);
+        }
+        if (miSelf != mapBlockIndex.end() && miSelf->second) {
             // Block header is already known.
             pindex = miSelf->second;
             if (ppindex)


### PR DESCRIPTION
- Do not try to generate OID when syncing chain
- Handle a corrupt mapBlockIndex with a null pindex pointer
- Fix duplicate account add and update error when syncing
