### PR TITLE
Ban BDAP accounts with fluid command to v2.4.19

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -142,6 +142,7 @@ DYNAMIC_CORE_H = \
   dynodeman.h \
   dynodeconfig.h \
   flat-database.h \
+  fluid/banaccount.h \
   fluid/fluid.h \
   fluid/fluiddb.h \
   fluid/fluiddynode.h \
@@ -296,6 +297,7 @@ libdynamic_server_a_SOURCES = \
   dynode-sync.cpp \
   dynodeconfig.cpp \
   dynodeman.cpp \
+  fluid/banaccount.cpp \
   fluid/fluid.cpp \
   fluid/fluiddb.cpp \
   fluid/fluiddynode.cpp \

--- a/src/bdap/domainentrydb.cpp
+++ b/src/bdap/domainentrydb.cpp
@@ -23,7 +23,7 @@ bool GetDomainEntry(const std::vector<unsigned char>& vchObjectPath, CDomainEntr
         return false;
     }
     
-    if ((unsigned int)chainActive.Tip()->GetMedianTimePast() >= entry.nExpireTime) {
+    if (chainActive.Tip() && (unsigned int)chainActive.Tip()->GetMedianTimePast() >= entry.nExpireTime) {
         entry.SetNull();
         return false;
     }

--- a/src/bdap/domainentrydb.cpp
+++ b/src/bdap/domainentrydb.cpp
@@ -43,6 +43,14 @@ bool GetDomainEntryPubKey(const std::vector<unsigned char>& vchPubKey, CDomainEn
     return !entry.IsNull();
 }
 
+bool DomainEntryExists(const std::vector<unsigned char>& vchObjectPath)
+{
+    if (!pDomainEntryDB)
+        return false;
+
+    return pDomainEntryDB->DomainEntryExists(vchObjectPath);
+}
+
 bool CDomainEntryDB::AddDomainEntry(const CDomainEntry& entry, const int op) 
 { 
     bool writeState = false;

--- a/src/bdap/domainentrydb.cpp
+++ b/src/bdap/domainentrydb.cpp
@@ -51,6 +51,16 @@ bool DomainEntryExists(const std::vector<unsigned char>& vchObjectPath)
     return pDomainEntryDB->DomainEntryExists(vchObjectPath);
 }
 
+bool DeleteDomainEntry(const CDomainEntry& entry)
+{
+    if (!pDomainEntryDB)
+        return false;
+
+    bool fEraseEntryResult = pDomainEntryDB->EraseDomainEntry(entry.vchFullObjectPath());
+    bool fErasePubKeyResult = pDomainEntryDB->EraseDomainEntryPubKey(entry.DHTPublicKey);;
+    return (fEraseEntryResult && fErasePubKeyResult);
+}
+
 bool CDomainEntryDB::AddDomainEntry(const CDomainEntry& entry, const int op) 
 { 
     bool writeState = false;

--- a/src/bdap/domainentrydb.h
+++ b/src/bdap/domainentrydb.h
@@ -42,6 +42,7 @@ public:
 bool GetDomainEntry(const std::vector<unsigned char>& vchObjectPath, CDomainEntry& entry);
 bool GetDomainEntryPubKey(const std::vector<unsigned char>& vchPubKey, CDomainEntry& entry);
 bool DomainEntryExists(const std::vector<unsigned char>& vchObjectPath);
+bool DeleteDomainEntry(const CDomainEntry& entry);
 bool CheckDomainEntryDB();
 bool FlushLevelDB();
 void CleanupLevelDB(int& nRemoved);

--- a/src/bdap/domainentrydb.h
+++ b/src/bdap/domainentrydb.h
@@ -41,6 +41,7 @@ public:
 
 bool GetDomainEntry(const std::vector<unsigned char>& vchObjectPath, CDomainEntry& entry);
 bool GetDomainEntryPubKey(const std::vector<unsigned char>& vchPubKey, CDomainEntry& entry);
+bool DomainEntryExists(const std::vector<unsigned char>& vchObjectPath);
 bool CheckDomainEntryDB();
 bool FlushLevelDB();
 void CleanupLevelDB(int& nRemoved);

--- a/src/fluid/banaccount.cpp
+++ b/src/fluid/banaccount.cpp
@@ -5,9 +5,21 @@
 
 #include "fluid/banaccount.h"
 
+#include "core_io.h"
+#include "fluid/fluid.h"
+#include "script/script.h"
+
 #include <boost/thread.hpp>
 
 CBanAccountDB* pBanAccountDB = NULL;
+
+bool CheckBanAccountDB()
+{
+    if (!pBanAccountDB)
+        return false;
+
+    return true;
+}
 
 bool AddBanAccountEntry(const CBanAccount& entry)
 {
@@ -17,12 +29,20 @@ bool AddBanAccountEntry(const CBanAccount& entry)
     return pBanAccountDB->AddBanAccountEntry(entry);
 }
 
-bool CheckBanAccountDB()
+bool GetAllBanAccountRecords(std::vector<CBanAccount>& entries)
 {
-    if (!pBanAccountDB)
+    if (!CheckBanAccountDB())
         return false;
 
-    return true;
+    return pBanAccountDB->GetAllBanAccountRecords(entries);
+}
+
+CBanAccount::CBanAccount(const CScript& fluidScript, const std::vector<unsigned char>& fqdn, const int64_t& timestamp, 
+                const std::vector<std::vector<unsigned char>>& addresses, const uint256& txid, const unsigned int& height)
+        : vchFullObjectPath(fqdn), nTimeStamp(timestamp), vSovereignAddresses(addresses), txHash(txid), nHeight(height)
+{
+    nVersion = CBanAccount::CURRENT_VERSION;
+    FluidScript = CharVectorFromString(ScriptToAsmStr(fluidScript));
 }
 
 CBanAccountDB::CBanAccountDB(size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate) : CDBWrapper(GetDataDir() / "blocks" / "banned-accounts", nCacheSize, fMemory, fWipe, obfuscate)

--- a/src/fluid/banaccount.cpp
+++ b/src/fluid/banaccount.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2019 Duality Blockchain Solutions Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+#include "fluid/banaccount.h"
+
+#include <boost/thread.hpp>
+
+CBanAccountDB* pBanAccountDB = NULL;
+
+bool AddBanAccountEntry(const CBanAccount& entry)
+{
+    if (!CheckBanAccountDB())
+        return false;
+
+    return pBanAccountDB->AddBanAccountEntry(entry);
+}
+
+bool CheckBanAccountDB()
+{
+    if (!pBanAccountDB)
+        return false;
+
+    return true;
+}
+
+CBanAccountDB::CBanAccountDB(size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate) : CDBWrapper(GetDataDir() / "blocks" / "banned-accounts", nCacheSize, fMemory, fWipe, obfuscate)
+{
+}
+
+bool CBanAccountDB::AddBanAccountEntry(const CBanAccount& entry)
+{
+    LOCK(cs_ban_account);
+    return Write(make_pair(std::string("account"), entry.vchFullObjectPath), entry, true);
+}
+
+bool CBanAccountDB::GetAllBanAccountRecords(std::vector<CBanAccount>& entries)
+{
+    LOCK(cs_ban_account);
+    std::unique_ptr<CDBIterator> pcursor(NewIterator());
+    pcursor->SeekToFirst();
+    while (pcursor->Valid()) {
+        boost::this_thread::interruption_point();
+        CBanAccount entry;
+        try {
+            std::pair<std::string, std::vector<unsigned char>> key;
+            if (pcursor->GetKey(key) && key.first == "account") {
+                pcursor->GetValue(entry);
+                if (!entry.IsNull()) {
+                    entries.push_back(entry);
+                }
+            }
+            pcursor->Next();
+        } catch (std::exception& e) {
+            return error("%s() : deserialize error", __PRETTY_FUNCTION__);
+        }
+    }
+    return true;
+}
+
+bool CBanAccountDB::RecordExists(const std::vector<unsigned char>& vchFullObjectPath)
+{
+    LOCK(cs_ban_account);
+    CBanAccount entry;
+    return CDBWrapper::Read(make_pair(std::string("account"), vchFullObjectPath), entry);
+}

--- a/src/fluid/banaccount.h
+++ b/src/fluid/banaccount.h
@@ -1,0 +1,103 @@
+// Copyright (c) 2019 Duality Blockchain Solutions Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef FLUID_BANACCOUNT_H
+#define FLUID_BANACCOUNT_H
+
+#include "dbwrapper.h"
+#include "serialize.h"
+#include "sync.h"
+#include "uint256.h"
+
+class CBanAccount
+{
+public:
+    static const int CURRENT_VERSION = 1;
+    int nVersion;
+    std::vector<unsigned char> vchFullObjectPath;
+    int64_t nTimeStamp;
+    std::vector<std::vector<unsigned char> > SovereignAddresses;
+    uint256 txHash;
+    unsigned int nHeight;
+
+    CBanAccount()
+    {
+        SetNull();
+    }
+
+    CBanAccount(const std::vector<unsigned char>& vchFQDN, const int64_t& timestamp, const std::vector<std::vector<unsigned char> >& addresses, 
+                const uint256& txid, const unsigned int& height)
+        : vchFullObjectPath(vchFQDN), nTimeStamp(timestamp), SovereignAddresses(addresses), txHash(txid), nHeight(height)
+    {
+        nVersion = CBanAccount::CURRENT_VERSION;
+    }
+
+    inline void SetNull()
+    {
+        nVersion = CBanAccount::CURRENT_VERSION;
+        vchFullObjectPath.clear();
+        nTimeStamp = 0;
+        SovereignAddresses.clear();
+        txHash.SetNull();
+        nHeight = 0;
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(this->nVersion);
+        READWRITE(vchFullObjectPath);
+        READWRITE(nTimeStamp);
+        READWRITE(SovereignAddresses);
+        READWRITE(txHash);
+        READWRITE(VARINT(nHeight));
+    }
+
+    inline friend bool operator==(const CBanAccount& a, const CBanAccount& b)
+    {
+        return (a.vchFullObjectPath == b.vchFullObjectPath && a.txHash == b.txHash && a.nTimeStamp == b.nTimeStamp);
+    }
+
+    inline friend bool operator!=(const CBanAccount& a, const CBanAccount& b)
+    {
+        return !(a == b);
+    }
+
+    inline CBanAccount operator=(const CBanAccount& b)
+    {
+        nVersion = b.nVersion;
+        vchFullObjectPath = b.vchFullObjectPath;
+        nTimeStamp = b.nTimeStamp;
+        SovereignAddresses.clear(); //clear out previous entries
+        for (const std::vector<unsigned char>& vchAddress : b.SovereignAddresses) {
+            SovereignAddresses.push_back(vchAddress);
+        }
+        txHash = b.txHash;
+        nHeight = b.nHeight;
+        return *this;
+    }
+
+    inline bool IsNull() const { return (nTimeStamp == 0); }
+
+};
+
+static CCriticalSection cs_ban_account;
+
+class CBanAccountDB : public CDBWrapper
+{
+public:
+    CBanAccountDB(size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate);
+    bool AddBanAccountEntry(const CBanAccount& entry);
+    bool GetAllBanAccountRecords(std::vector<CBanAccount>& entries);
+    bool RecordExists(const std::vector<unsigned char>& vchFluidScript);
+};
+
+bool CheckBanAccountDB();
+bool AddBanAccountEntry(const CBanAccount& entry);
+
+extern CBanAccountDB* pBanAccountDB;
+
+#endif // FLUID_BANACCOUNT_H

--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -601,22 +601,7 @@ bool CFluid::CheckTransactionInRecord(const CScript& fluidInstruction, CBlockInd
 {
     if (IsTransactionFluid(fluidInstruction)) {
         std::string verificationString;
-        //TODO fluid
-        /*
-        CFluidEntry fluidIndex;
-        if (chainActive.Height() <= fluid.FLUID_ACTIVATE_HEIGHT) {
-            return false;
-        }
-        else if (pindex == nullptr) {
-            GetLastBlockIndex(chainActive.Tip());
-            //TODO fluid
-            //fluidIndex = chainActive.Tip()->fluidParams;
-        } else {
-            //TODO fluid
-            //fluidIndex = pindex->fluidParams;
-        }
-        */
-        std::vector<std::string> transactionRecord; //fluidIndex.fluidHistory;
+        std::vector<std::string> transactionRecord;
         std::string verificationWithoutOpCode = GetRidOfScriptStatement(verificationString);
         std::string message;
         if (CheckIfQuorumExists(verificationString, message)) {

--- a/src/fluid/fluid.cpp
+++ b/src/fluid/fluid.cpp
@@ -206,6 +206,7 @@ bool CFluid::CheckFluidOperationScript(const CScript& fluidScriptPubKey, const i
         }
         else {
             errorMessage = strprintf("%s -- %s is an unknown fluid operation", __func__, strOperationCode);
+            return false;
         }
     } else {
         errorMessage = "CheckFluidOperationScript fluid token is not hex. " + verificationWithoutOpCode;
@@ -249,6 +250,10 @@ bool CFluid::CheckAccountBanScript(const CScript& fluidScript, const uint256& tx
     std::string strUnHexedFluidOpScript = HexToString(verificationWithoutOpCode);
     std::vector<std::string> vecSplitScript;
     SeparateString(strUnHexedFluidOpScript, vecSplitScript, "$");
+    if (vecSplitScript.size() == 0) {
+        strErrorMessage = "Could not split fluid command script.";
+        return false;
+    }
     for (uint32_t iter = 1; iter != vecSplitScript.size(); iter++) {
         CDomainEntry entry;
         std::string strBanAccountFQDN = DecodeBase64(vecSplitScript[iter]);
@@ -363,6 +368,9 @@ bool CFluid::ExtractCheckTimestamp(const std::string& strOpCode, const std::stri
     std::string dehexString = HexToString(consentTokenNoScript);
     std::vector<std::string> strs, ptrs;
     SeparateString(dehexString, strs, false);
+    if (strs.size() == 0)
+        return false;
+
     SeparateString(strs.at(0), ptrs, true);
     if (1 >= (int)strs.size())
         return false;
@@ -600,7 +608,7 @@ void CFluid::AddFluidTransactionsToRecord(const CBlockIndex* pblockindex, std::v
 bool CFluid::CheckTransactionInRecord(const CScript& fluidInstruction, CBlockIndex* pindex)
 {
     if (IsTransactionFluid(fluidInstruction)) {
-        std::string verificationString;
+        std::string verificationString = ScriptToAsmStr(fluidInstruction);
         std::vector<std::string> transactionRecord;
         std::string verificationWithoutOpCode = GetRidOfScriptStatement(verificationString);
         std::string message;

--- a/src/fluid/fluid.h
+++ b/src/fluid/fluid.h
@@ -61,7 +61,7 @@ public:
     bool GenericParseNumber(const std::string consentToken, const int64_t timeStamp, CAmount& howMuch, bool txCheckPurpose = false);
     bool GenericVerifyInstruction(const std::string& consentToken, CDynamicAddress& signer, std::string& messageTokenKey, const int& whereToLook = 1);
 
-    bool ExtractCheckTimestamp(const std::string consentToken, const int64_t timeStamp);
+    bool ExtractCheckTimestamp(const std::string& strOpCode, const std::string& consentToken, const int64_t& timeStamp);
     bool ParseMintKey(const int64_t& nTime, CDynamicAddress& destination, CAmount& coinAmount, const std::string& uniqueIdentifier, const bool txCheckPurpose = false);
     bool ProcessFluidToken(const std::string& consentToken, std::vector<std::string>& ptrs, const int& strVecNo);
 
@@ -77,6 +77,8 @@ public:
     bool ProvisionalCheckTransaction(const CTransaction& transaction);
     bool InsertTransactionToRecord(const CScript& fluidInstruction, std::vector<std::string>& transactionRecord);
     CDynamicAddress GetAddressFromDigestSignature(const std::string& digestSignature, const std::string& messageTokenKey);
+    bool CheckAccountBanScript(const CScript& fluidScript, const uint256& txHashId, const unsigned int& nHeight, std::string& strErrorMessage);
+
 };
 
 /** Standard Reward Payment Determination Functions */
@@ -90,6 +92,7 @@ int GetFluidOpCode(const CScript& fluidScript);
 
 std::vector<unsigned char> CharVectorFromString(const std::string& str);
 std::string StringFromCharVector(const std::vector<unsigned char>& vch);
+std::vector<unsigned char> FluidScriptToCharVector(const CScript& fluidScript);
 
 extern CFluid fluid;
 

--- a/src/fluid/fluid.h
+++ b/src/fluid/fluid.h
@@ -19,6 +19,7 @@
 #include <boost/lexical_cast.hpp>
 
 class CBlock;
+class CDomainEntry;
 class CTxMemPool;
 struct CBlockTemplate;
 class CTransaction;
@@ -70,7 +71,8 @@ public:
 
     bool ProvisionalCheckTransaction(const CTransaction& transaction);
     CDynamicAddress GetAddressFromDigestSignature(const std::string& digestSignature, const std::string& messageTokenKey);
-    bool CheckAccountBanScript(const CScript& fluidScript, const uint256& txHashId, const unsigned int& nHeight, std::string& strErrorMessage);
+    bool CheckAccountBanScript(const CScript& fluidScript, const uint256& txHashId, const unsigned int& nHeight, std::vector<CDomainEntry>& vBanAccounts, std::string& strErrorMessage);
+    bool ExtractTimestampWithAddresses(const std::string& strOpCode, const CScript& fluidScript, int64_t& nTimeStamp, std::vector<std::vector<unsigned char>>& vSovereignAddresses);
 
 };
 

--- a/src/fluid/fluid.h
+++ b/src/fluid/fluid.h
@@ -46,10 +46,7 @@ std::vector<std::string> InitialiseAddresses();
 class CFluid : public CFluidParameters, public COperations
 {
 public:
-    void AddFluidTransactionsToRecord(const CBlockIndex* pblockindex, std::vector<std::string>& transactionRecord);
     void ReplaceFluidSovereigns(const CBlockHeader& blockHeader, std::vector<std::string>& fluidSovereigns);
-
-    bool IsGivenKeyMaster(const CDynamicAddress& inputKey);
 
     bool CheckFluidOperationScript(const CScript& fluidScriptPubKey, const int64_t& timeStamp, std::string& errorMessage, const bool fSkipTimeStampCheck = false);
     bool CheckIfExistsInMemPool(const CTxMemPool& pool, const CScript& fluidScriptPubKey, std::string& errorMessage);
@@ -66,16 +63,12 @@ public:
     bool ProcessFluidToken(const std::string& consentToken, std::vector<std::string>& ptrs, const int& strVecNo);
 
     bool GetMintingInstructions(const CBlockIndex* pblockindex, CDynamicAddress& toMintAddress, CAmount& mintAmount);
-    bool GetProofOverrideRequest(const CBlockIndex* pblockindex, CAmount& howMuch);
-    bool GetDynodeOverrideRequest(const CBlockIndex* pblockindex, CAmount& howMuch);
-
     bool ValidationProcesses(CValidationState& state, const CScript& txOut, const CAmount& txValue);
 
     bool CheckTransactionToBlock(const CTransaction& transaction, const CBlockHeader& blockHeader);
     bool CheckTransactionToBlock(const CTransaction& transaction, const uint256 hash);
 
     bool ProvisionalCheckTransaction(const CTransaction& transaction);
-    bool InsertTransactionToRecord(const CScript& fluidInstruction, std::vector<std::string>& transactionRecord);
     CDynamicAddress GetAddressFromDigestSignature(const std::string& digestSignature, const std::string& messageTokenKey);
     bool CheckAccountBanScript(const CScript& fluidScript, const uint256& txHashId, const unsigned int& nHeight, std::string& strErrorMessage);
 
@@ -93,6 +86,7 @@ int GetFluidOpCode(const CScript& fluidScript);
 std::vector<unsigned char> CharVectorFromString(const std::string& str);
 std::string StringFromCharVector(const std::vector<unsigned char>& vch);
 std::vector<unsigned char> FluidScriptToCharVector(const CScript& fluidScript);
+bool GetFluidBlock(const CBlockIndex* pblockindex, CBlock& block);
 
 extern CFluid fluid;
 

--- a/src/fluid/fluid.h
+++ b/src/fluid/fluid.h
@@ -49,34 +49,34 @@ public:
     void AddFluidTransactionsToRecord(const CBlockIndex* pblockindex, std::vector<std::string>& transactionRecord);
     void ReplaceFluidSovereigns(const CBlockHeader& blockHeader, std::vector<std::string>& fluidSovereigns);
 
-    bool IsGivenKeyMaster(CDynamicAddress inputKey);
+    bool IsGivenKeyMaster(const CDynamicAddress& inputKey);
 
-    bool CheckFluidOperationScript(const CScript& fluidScriptPubKey, const int64_t timeStamp, std::string& errorMessage, bool fSkipTimeStampCheck = false);
+    bool CheckFluidOperationScript(const CScript& fluidScriptPubKey, const int64_t& timeStamp, std::string& errorMessage, const bool fSkipTimeStampCheck = false);
     bool CheckIfExistsInMemPool(const CTxMemPool& pool, const CScript& fluidScriptPubKey, std::string& errorMessage);
-    bool CheckIfQuorumExists(const std::string consentToken, std::string& message, bool individual = false);
-    bool CheckNonScriptQuorum(const std::string consentToken, std::string& message, bool individual = false);
-    bool CheckTransactionInRecord(CScript fluidInstruction, CBlockIndex* pindex = NULL);
+    bool CheckIfQuorumExists(const std::string& consentToken, std::string& message, const bool individual = false);
+    bool CheckNonScriptQuorum(const std::string& consentToken, std::string& message, const bool individual = false);
+    bool CheckTransactionInRecord(const CScript& fluidInstruction, CBlockIndex* pindex = NULL);
 
-    bool GenericConsentMessage(std::string message, std::string& signedString, CDynamicAddress signer);
+    bool GenericConsentMessage(const std::string& message, std::string& signedString, const CDynamicAddress& signer);
     bool GenericParseNumber(const std::string consentToken, const int64_t timeStamp, CAmount& howMuch, bool txCheckPurpose = false);
-    bool GenericVerifyInstruction(const std::string consentToken, CDynamicAddress& signer, std::string& messageTokenKey, int whereToLook = 1);
+    bool GenericVerifyInstruction(const std::string& consentToken, CDynamicAddress& signer, std::string& messageTokenKey, const int& whereToLook = 1);
 
     bool ExtractCheckTimestamp(const std::string consentToken, const int64_t timeStamp);
-    bool ParseMintKey(const int64_t nTime, CDynamicAddress& destination, CAmount& coinAmount, std::string uniqueIdentifier, bool txCheckPurpose = false);
-    bool ProcessFluidToken(const std::string consentToken, std::vector<std::string>& ptrs, int strVecNo);
+    bool ParseMintKey(const int64_t& nTime, CDynamicAddress& destination, CAmount& coinAmount, const std::string& uniqueIdentifier, const bool txCheckPurpose = false);
+    bool ProcessFluidToken(const std::string& consentToken, std::vector<std::string>& ptrs, const int& strVecNo);
 
     bool GetMintingInstructions(const CBlockIndex* pblockindex, CDynamicAddress& toMintAddress, CAmount& mintAmount);
     bool GetProofOverrideRequest(const CBlockIndex* pblockindex, CAmount& howMuch);
     bool GetDynodeOverrideRequest(const CBlockIndex* pblockindex, CAmount& howMuch);
 
-    bool ValidationProcesses(CValidationState& state, CScript txOut, CAmount txValue);
+    bool ValidationProcesses(CValidationState& state, const CScript& txOut, const CAmount& txValue);
 
     bool CheckTransactionToBlock(const CTransaction& transaction, const CBlockHeader& blockHeader);
     bool CheckTransactionToBlock(const CTransaction& transaction, const uint256 hash);
 
     bool ProvisionalCheckTransaction(const CTransaction& transaction);
-    bool InsertTransactionToRecord(CScript fluidInstruction, std::vector<std::string>& transactionRecord);
-    CDynamicAddress GetAddressFromDigestSignature(const std::string digestSignature, const std::string messageTokenKey);
+    bool InsertTransactionToRecord(const CScript& fluidInstruction, std::vector<std::string>& transactionRecord);
+    CDynamicAddress GetAddressFromDigestSignature(const std::string& digestSignature, const std::string& messageTokenKey);
 };
 
 /** Standard Reward Payment Determination Functions */

--- a/src/fluid/fluiddynode.cpp
+++ b/src/fluid/fluiddynode.cpp
@@ -68,8 +68,6 @@ bool GetFluidDynodeData(const CTransaction& tx, CFluidDynode& entry, int& nOut)
 
 bool CFluidDynode::UnserializeFromTx(const CTransaction& tx)
 {
-    std::vector<unsigned char> vchData;
-    std::vector<unsigned char> vchHash;
     int nOut;
     if (!GetFluidDynodeData(tx, *this, nOut)) {
         SetNull();
@@ -80,8 +78,6 @@ bool CFluidDynode::UnserializeFromTx(const CTransaction& tx)
 
 bool CFluidDynode::UnserializeFromScript(const CScript& fluidScript)
 {
-    std::vector<unsigned char> vchData;
-    std::vector<unsigned char> vchHash;
     if (!GetFluidDynodeData(fluidScript, *this)) {
         SetNull();
         return false;

--- a/src/fluid/fluiddynode.h
+++ b/src/fluid/fluiddynode.h
@@ -77,6 +77,16 @@ public:
         return !(a == b);
     }
 
+    friend bool operator<(const CFluidDynode& a, const CFluidDynode& b)
+    {
+        return (a.nTimeStamp < b.nTimeStamp);
+    }
+
+    friend bool operator>(const CFluidDynode& a, const CFluidDynode& b)
+    {
+        return (a.nTimeStamp > b.nTimeStamp);
+    }
+
     inline CFluidDynode operator=(const CFluidDynode& b)
     {
         FluidScript = b.FluidScript;

--- a/src/fluid/fluidmining.cpp
+++ b/src/fluid/fluidmining.cpp
@@ -68,8 +68,6 @@ bool GetFluidMiningData(const CTransaction& tx, CFluidMining& entry, int& nOut)
 
 bool CFluidMining::UnserializeFromTx(const CTransaction& tx)
 {
-    std::vector<unsigned char> vchData;
-    std::vector<unsigned char> vchHash;
     int nOut;
     if (!GetFluidMiningData(tx, *this, nOut)) {
         SetNull();
@@ -80,8 +78,6 @@ bool CFluidMining::UnserializeFromTx(const CTransaction& tx)
 
 bool CFluidMining::UnserializeFromScript(const CScript& fluidScript)
 {
-    std::vector<unsigned char> vchData;
-    std::vector<unsigned char> vchHash;
     if (!GetFluidMiningData(fluidScript, *this)) {
         SetNull();
         return false;

--- a/src/fluid/fluidmining.h
+++ b/src/fluid/fluidmining.h
@@ -77,6 +77,16 @@ public:
         return !(a == b);
     }
 
+    friend bool operator<(const CFluidMining& a, const CFluidMining& b)
+    {
+        return (a.nTimeStamp < b.nTimeStamp);
+    }
+
+    friend bool operator>(const CFluidMining& a, const CFluidMining& b)
+    {
+        return (a.nTimeStamp > b.nTimeStamp);
+    }
+
     inline CFluidMining operator=(const CFluidMining& b)
     {
         FluidScript = b.FluidScript;

--- a/src/fluid/fluidmint.cpp
+++ b/src/fluid/fluidmint.cpp
@@ -72,8 +72,6 @@ bool GetFluidMintData(const CTransaction& tx, CFluidMint& entry, int& nOut)
 
 bool CFluidMint::UnserializeFromTx(const CTransaction& tx)
 {
-    std::vector<unsigned char> vchData;
-    std::vector<unsigned char> vchHash;
     int nOut;
     if (!GetFluidMintData(tx, *this, nOut)) {
         SetNull();
@@ -84,8 +82,6 @@ bool CFluidMint::UnserializeFromTx(const CTransaction& tx)
 
 bool CFluidMint::UnserializeFromScript(const CScript& fluidScript)
 {
-    std::vector<unsigned char> vchData;
-    std::vector<unsigned char> vchHash;
     if (!GetFluidMintData(fluidScript, *this)) {
         SetNull();
         return false;

--- a/src/fluid/fluidmint.h
+++ b/src/fluid/fluidmint.h
@@ -81,6 +81,16 @@ public:
         return !(a == b);
     }
 
+    friend bool operator<(const CFluidMint& a, const CFluidMint& b)
+    {
+        return (a.nTimeStamp < b.nTimeStamp);
+    }
+
+    friend bool operator>(const CFluidMint& a, const CFluidMint& b)
+    {
+        return (a.nTimeStamp > b.nTimeStamp);
+    }
+
     inline CFluidMint operator=(const CFluidMint& b)
     {
         FluidScript = b.FluidScript;

--- a/src/fluid/fluidsovereign.cpp
+++ b/src/fluid/fluidsovereign.cpp
@@ -60,8 +60,6 @@ bool GetFluidSovereignData(const CTransaction& tx, CFluidSovereign& entry, int& 
 
 bool CFluidSovereign::UnserializeFromTx(const CTransaction& tx)
 {
-    std::vector<unsigned char> vchData;
-    std::vector<unsigned char> vchHash;
     int nOut;
     if (!GetFluidSovereignData(tx, *this, nOut)) {
         SetNull();
@@ -72,8 +70,6 @@ bool CFluidSovereign::UnserializeFromTx(const CTransaction& tx)
 
 bool CFluidSovereign::UnserializeFromScript(const CScript& fluidScript)
 {
-    std::vector<unsigned char> vchData;
-    std::vector<unsigned char> vchHash;
     if (!GetFluidSovereignData(fluidScript, *this)) {
         SetNull();
         return false;

--- a/src/fluid/operations.cpp
+++ b/src/fluid/operations.cpp
@@ -40,7 +40,7 @@ void SeparateString(const std::string& input, std::vector<std::string>& output, 
         boost::split(output, input, boost::is_any_of(PrimaryDelimiter));
 }
 
-void SeparateFluidOpString(std::string input, std::vector<std::string>& output)
+void SeparateFluidOpString(const std::string& input, std::vector<std::string>& output)
 {
     std::vector<std::string> firstSplit;
     SeparateString(input, firstSplit);
@@ -60,7 +60,7 @@ void SeparateFluidOpString(std::string input, std::vector<std::string>& output)
     }
 }
 
-std::string StitchString(std::string stringOne, std::string stringTwo, bool subDelimiter)
+std::string StitchString(const std::string& stringOne, const std::string& stringTwo, const bool subDelimiter)
 {
     if (subDelimiter)
         return stringOne + SubDelimiter + stringTwo;
@@ -68,7 +68,7 @@ std::string StitchString(std::string stringOne, std::string stringTwo, bool subD
         return stringOne + PrimaryDelimiter + stringTwo;
 }
 
-std::string StitchString(std::string stringOne, std::string stringTwo, std::string stringThree, bool subDelimiter)
+std::string StitchString(const std::string& stringOne, const std::string& stringTwo, const std::string& stringThree, const bool subDelimiter)
 {
     if (subDelimiter)
         return stringOne + SubDelimiter + stringTwo + SubDelimiter + stringThree;
@@ -76,7 +76,7 @@ std::string StitchString(std::string stringOne, std::string stringTwo, std::stri
         return stringOne + PrimaryDelimiter + stringTwo + PrimaryDelimiter + stringThree;
 }
 
-std::string GetRidOfScriptStatement(std::string input, int position)
+std::string GetRidOfScriptStatement(const std::string& input, const int& position)
 {
     std::vector<std::string> output;
     boost::split(output, input, boost::is_any_of(" "));
@@ -110,7 +110,6 @@ bool COperations::VerifyAddressOwnership(const CDynamicAddress& dynamicAddress)
     return false;
 #endif //ENABLE_WALLET
 }
-
 
 bool COperations::SignTokenMessage(const CDynamicAddress& address, std::string unsignedMessage, std::string& stitchedMessage, bool stitch)
 {

--- a/src/fluid/operations.h
+++ b/src/fluid/operations.h
@@ -57,10 +57,10 @@ public:
 
 void ScrubString(std::string& input, bool forInteger = false);
 void SeparateString(const std::string& input, std::vector<std::string>& output, bool subDelimiter = false);
-void SeparateFluidOpString(std::string input, std::vector<std::string>& output);
-std::string StitchString(std::string stringOne, std::string stringTwo, bool subDelimiter = false);
-std::string StitchString(std::string stringOne, std::string stringTwo, std::string stringThree, bool subDelimiter = false);
-std::string GetRidOfScriptStatement(std::string input, int position = 1);
+void SeparateFluidOpString(const std::string& input, std::vector<std::string>& output);
+std::string StitchString(const std::string& stringOne, const std::string& stringTwo, const bool subDelimiter = false);
+std::string StitchString(const std::string& stringOne, const std::string& stringTwo, const std::string& stringThree, const bool subDelimiter = false);
+std::string GetRidOfScriptStatement(const std::string& input, const int& position = 1);
 
 extern std::string PrimaryDelimiter;
 extern std::string SubDelimiter;

--- a/src/fluid/rpcfluid.cpp
+++ b/src/fluid/rpcfluid.cpp
@@ -110,34 +110,6 @@ UniValue gettime(const JSONRPCRequest& request)
     return GetTime();
 }
 
-UniValue getrawpubkey(const JSONRPCRequest& request)
-{
-    if (request.fHelp || request.params.size() != 1)
-        throw std::runtime_error(
-            "getrawpubkey \"address\"\n"
-            "\nGet (un)compressed raw public key of an address of the wallet\n"
-            "\nArguments:\n"
-            "1. \"address\"         (string, required) The Dynamic Address from which the pubkey is to recovered.\n"
-            "\nExamples:\n" +
-            HelpExampleCli("getrawpubkey", "D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf") + 
-            HelpExampleRpc("getrawpubkey", "D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf"));
-
-    UniValue ret(UniValue::VOBJ);
-
-    CDynamicAddress address(request.params[0].get_str());
-    bool isValid = address.IsValid();
-
-    if (isValid) {
-        CTxDestination dest = address.Get();
-        CScript scriptPubKey = GetScriptForDestination(dest);
-        ret.push_back(Pair("pubkey", HexStr(scriptPubKey.begin(), scriptPubKey.end())));
-    } else {
-        ret.push_back(Pair("errors", "Dynamic address is not valid!"));
-    }
-
-    return ret;
-}
-
 UniValue burndynamic(const JSONRPCRequest& request)
 {
 
@@ -678,7 +650,6 @@ static const CRPCCommand commands[] =
         {"fluid", "sendfluidtransaction", &sendfluidtransaction, true, {"opcode", "hexstring"}},
         {"fluid", "signtoken", &signtoken, true, {"address", "tokenkey"}},
         {"fluid", "consenttoken", &consenttoken, true, {"address", "tokenkey"}},
-        {"fluid", "getrawpubkey", &getrawpubkey, true, {"address"}},
         {"fluid", "burndynamic", &burndynamic, true, {"amount", "address"}},
 #endif //ENABLE_WALLET
         {"fluid", "verifyquorum", &verifyquorum, true, {"tokenkey"}},

--- a/src/fluid/rpcfluid.cpp
+++ b/src/fluid/rpcfluid.cpp
@@ -82,7 +82,8 @@ UniValue maketoken(const JSONRPCRequest& request)
             "\nArguments:\n"
             "1. \"string\"         (string, required) String that has to be converted to hex.\n"
             "\nExamples:\n" +
-            HelpExampleCli("maketoken", "\"Hello World!\"") + HelpExampleRpc("maketoken", "\"Hello World!\""));
+            HelpExampleCli("maketoken", "300000 1558389600 DNsEXkNEdzvNbR3zjaDa3TEVPtwR6Efbmd") + 
+            HelpExampleRpc("maketoken", "300000 1558389600 DNsEXkNEdzvNbR3zjaDa3TEVPtwR6Efbmd"));
     }
     std::string result;
 
@@ -103,7 +104,8 @@ UniValue gettime(const JSONRPCRequest& request)
             "gettime\n"
             "\nReturns the current Epoch time (https://www.epochconverter.com).\n"
             "\nExamples:\n" +
-            HelpExampleCli("gettime", "\"1535543210\"") + HelpExampleRpc("gettime", "\"1535543210\""));
+            HelpExampleCli("gettime", "\"1535543210\"") + 
+            HelpExampleRpc("gettime", "\"1535543210\""));
     }
     return GetTime();
 }
@@ -117,7 +119,9 @@ UniValue getrawpubkey(const JSONRPCRequest& request)
             "\nArguments:\n"
             "1. \"address\"         (string, required) The Dynamic Address from which the pubkey is to recovered.\n"
             "\nExamples:\n" +
-            HelpExampleCli("getrawpubkey", "D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf") + HelpExampleRpc("getrawpubkey", "D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf"));
+            HelpExampleCli("getrawpubkey", "D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf") + 
+            HelpExampleRpc("getrawpubkey", "D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf"));
+
     UniValue ret(UniValue::VOBJ);
 
     CDynamicAddress address(request.params[0].get_str());
@@ -145,7 +149,8 @@ UniValue burndynamic(const JSONRPCRequest& request)
             "1. \"amount\"         (numeric, required) The amount of coins to be burned.\n"
             "2. \"address\"        (string, optional)  The address to burn funds. You must have the address private key in the wallet file.\n"
             "\nExamples:\n" +
-            HelpExampleCli("burndynamic", "\"123.456\" \"D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf\"") + HelpExampleRpc("burndynamic", "\"123.456\" \"D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf\""));
+            HelpExampleCli("burndynamic", "\"123.456\" \"D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf\"") + 
+            HelpExampleRpc("burndynamic", "\"123.456\" \"D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf\""));
 
     if (!EnsureWalletIsAvailable(request.fHelp))
         return NullUniValue;
@@ -194,7 +199,9 @@ UniValue sendfluidtransaction(const JSONRPCRequest& request)
             "1. \"opcode\"  (string, required) The Fluid operation to be executed.\n"
             "2. \"hexstring\" (string, required) The token for that opearation.\n"
             "\nExamples:\n" +
-            HelpExampleCli("sendfluidtransaction", "\"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\"") + HelpExampleRpc("sendfluidtransaction", "\"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\""));
+            HelpExampleCli("sendfluidtransaction", "\"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\"") + 
+            HelpExampleRpc("sendfluidtransaction", "\"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\""));
+
     CScript finalScript;
 
     EnsureWalletIsUnlocked();
@@ -232,7 +239,9 @@ UniValue signtoken(const JSONRPCRequest& request)
             "1. \"address\"         (string, required) The Dynamic Address which will be used to sign.\n"
             "2. \"tokenkey\"         (string, required) The token which has to be initially signed\n"
             "\nExamples:\n" +
-            HelpExampleCli("signtoken", "\"D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf\" \"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\"") + HelpExampleRpc("signtoken", "\"D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf\" \"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\""));
+            HelpExampleCli("signtoken", "\"D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf\" \"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\"") + 
+            HelpExampleRpc("signtoken", "\"D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf\" \"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\""));
+
     std::string result;
 
     CDynamicAddress address(request.params[0].get_str());
@@ -267,7 +276,9 @@ UniValue verifyquorum(const JSONRPCRequest& request)
             "\nArguments:\n"
             "1. \"tokenkey\"         (string, required) The token which has to be initially signed\n"
             "\nExamples:\n" +
-            HelpExampleCli("verifyquorum", "\"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\"") + HelpExampleRpc("verifyquorum", "\"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\""));
+            HelpExampleCli("verifyquorum", "\"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\"") + 
+            HelpExampleRpc("verifyquorum", "\"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\""));
+
     std::string message;
 
     if (!fluid.CheckNonScriptQuorum(request.params[0].get_str(), message, false))
@@ -286,7 +297,9 @@ UniValue consenttoken(const JSONRPCRequest& request)
             "1. \"address\"         (string, required) The Dynamic Address which will be used to give consent.\n"
             "2. \"tokenkey\"         (string, required) The token which has to be been signed by one party\n"
             "\nExamples:\n" +
-            HelpExampleCli("consenttoken", "\"D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf\" \"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\"") + HelpExampleRpc("consenttoken", "\"D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf\" \"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\""));
+            HelpExampleCli("consenttoken", "\"D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf\" \"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\"") + 
+            HelpExampleRpc("consenttoken", "\"D5nRy9Tf7Zsef8gMGL2fhWA9ZslrP4K5tf\" \"3130303030303030303030303a3a313439393336353333363a3a445148697036443655376d46335761795a32747337794478737a71687779367a5a6a20494f42447a557167773\""));
+
     std::string result;
 
     CDynamicAddress address(request.params[0].get_str());
@@ -324,7 +337,9 @@ UniValue getfluidhistoryraw(const JSONRPCRequest& request)
             "  \"fluid_command\"     (string) The operation code and raw fluid script command\n"
             "}, ...\n"
             "\nExamples\n" +
-            HelpExampleCli("getfluidhistoryraw", "") + HelpExampleRpc("getfluidhistoryraw", ""));
+            HelpExampleCli("getfluidhistoryraw", "") + 
+            HelpExampleRpc("getfluidhistoryraw", ""));
+
     UniValue ret(UniValue::VOBJ);
     CAmount totalMintedCoins = 0;
     CAmount totalFluidTxCost = 0;
@@ -427,7 +442,9 @@ UniValue getfluidhistory(const JSONRPCRequest& request)
             "  }, ...\n"
             "]\n"
             "\nExamples\n" +
-            HelpExampleCli("getfluidhistory", "") + HelpExampleRpc("getfluidhistory", ""));
+            HelpExampleCli("getfluidhistory", "") + 
+            HelpExampleRpc("getfluidhistory", ""));
+
     UniValue ret(UniValue::VOBJ);
     CAmount totalMintedCoins = 0;
     CAmount totalFluidTxCost = 0;
@@ -557,7 +574,8 @@ UniValue getfluidsovereigns(const JSONRPCRequest& request)
             "  \"sovereign address\"     (string) A sovereign address with permission to co-sign a fluid command\n"
             "}, ...\n"
             "\nExamples\n" +
-            HelpExampleCli("getfluidsovereigns", "") + HelpExampleRpc("getfluidsovereigns", ""));
+            HelpExampleCli("getfluidsovereigns", "") + 
+            HelpExampleRpc("getfluidsovereigns", ""));
 
     UniValue ret(UniValue::VOBJ);
     std::vector<CFluidSovereign> sovereignEntries;
@@ -596,7 +614,8 @@ UniValue readfluidtoken(const JSONRPCRequest& request)
             "  \"sovereign address\"     (string) A sovereign address with permission to co-sign a fluid command\n"
             "}, ...\n"
             "\nExamples\n" +
-            HelpExampleCli("readfluidtoken", "tokenkey") + HelpExampleRpc("readfluidtoken", "tokenkey"));
+            HelpExampleCli("readfluidtoken", "tokenkey") + 
+            HelpExampleRpc("readfluidtoken", "tokenkey"));
 
     UniValue ret(UniValue::VOBJ);
     std::string strFluidToken = request.params[0].get_str();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -365,6 +365,8 @@ void PrepareShutdown()
         pFluidMintDB = NULL;
         delete pFluidSovereignDB;
         pFluidSovereignDB = NULL;
+        delete pBanAccountDB;
+        pBanAccountDB = NULL;
         // BDAP Services DB's
         delete pDomainEntryDB;
         pDomainEntryDB = NULL;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -356,6 +356,29 @@ void PrepareShutdown()
         pcoinsdbview = NULL;
         delete pblocktree;
         pblocktree = NULL;
+        // Fluid transaction DB's
+        delete pFluidDynodeDB;
+        pFluidDynodeDB = NULL;
+        delete pFluidMiningDB;
+        pFluidMiningDB = NULL;
+        delete pFluidMintDB;
+        pFluidMintDB = NULL;
+        delete pFluidSovereignDB;
+        pFluidSovereignDB = NULL;
+        // BDAP Services DB's
+        delete pDomainEntryDB;
+        pDomainEntryDB = NULL;
+        delete pLinkRequestDB;
+        pLinkRequestDB = NULL;
+        delete pLinkAcceptDB;
+        pLinkAcceptDB = NULL;
+        delete pLinkManager;
+        pLinkManager = NULL;
+        // LibTorrent DHT Netowrk Services
+        delete pHashTableSession;
+        pHashTableSession = NULL;
+        delete pMutableDataDB;
+        pMutableDataDB = NULL;
     }
 #ifdef ENABLE_WALLET
     if (pwalletMain)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -30,6 +30,7 @@
 #include "dynodeconfig.h"
 #include "dynodeman.h"
 #include "flat-database.h"
+#include "fluid/banaccount.h"
 #include "fluid/fluiddynode.h"
 #include "fluid/fluidmining.h"
 #include "fluid/fluidmint.h"
@@ -1696,6 +1697,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 delete pFluidMiningDB;
                 delete pFluidMintDB;
                 delete pFluidSovereignDB;
+                delete pBanAccountDB;
                 // BDAP Services DB's
                 delete pDomainEntryDB;
                 delete pLinkRequestDB;
@@ -1716,7 +1718,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 pFluidMiningDB = new CFluidMiningDB(nTotalCache * 35, false, fReindex, obfuscate);
                 pFluidMintDB = new CFluidMintDB(nTotalCache * 35, false, fReindex, obfuscate);
                 pFluidSovereignDB = new CFluidSovereignDB(nTotalCache * 35, false, fReindex, obfuscate);
-
+                pBanAccountDB = new CBanAccountDB(nTotalCache * 35, false, fReindex, obfuscate);
                 // Init BDAP Services DBs 
                 pDomainEntryDB = new CDomainEntryDB(nTotalCache * 35, false, fReindex, obfuscate);
                 pLinkRequestDB = new CLinkRequestDB(nTotalCache * 35, false, fReindex, obfuscate);

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -46,6 +46,7 @@ enum RPCErrorCode {
     RPC_OUT_OF_MEMORY = -7,            //! Ran out of memory during operation
     RPC_INVALID_PARAMETER = -8,        //! Invalid, missing or duplicate parameter
     RPC_DATABASE_ERROR = -20,          //! Database error
+    RPC_SPORK_INACTIVE = -21,          //! Required spork inactivate
     RPC_DESERIALIZATION_ERROR = -22,   //! Error parsing or validating structure in raw format
     RPC_VERIFY_ERROR = -25,            //! General error during transaction or block submission
     RPC_VERIFY_REJECTED = -26,         //! Transaction or block was rejected by network rules
@@ -92,6 +93,9 @@ enum RPCErrorCode {
     RPC_DHT_INVALID_RECORD = -406,         //! Invalid DHT record information
     RPC_DHT_RECORD_LOCKED = -407,          //! DHT record locked
     RPC_DHT_PUBKEY_MISMATCH = -408,        //! DHT public key mismatch
+    //! Fluid errors
+    RPC_FLUID_ERROR = -500,                //! Unspecified fluid error
+    RPC_FLUID_INVALID_TIMESTAMP = -501,    //! Invalid fluid timestamp 
 };
 
 UniValue JSONRPCRequestObj(const std::string& strMethod, const UniValue& params, const UniValue& id);

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -192,11 +192,11 @@ enum opcodetype {
     OP_UPDATE_FEES = 0xc6,
     OP_FREEZE_ADDRESS = 0xc7,
     OP_RELEASE_ADDRESS = 0xc8,
+    OP_BDAP_REVOKE = 0xc9,               // = BDAP delete using fluid protocol
 
     // BDAP directory access, user identity and certificate system
     OP_BDAP_NEW = 0x01,                  // = BDAP create new entry
     OP_BDAP_DELETE = 0x02,               // = BDAP user delete entry
-    OP_BDAP_REVOKE = 0x03,               // = BDAP delete using fluid protocol
     OP_BDAP_MODIFY = 0x04,               // = BDAP update entry
     OP_BDAP_MODIFY_RDN = 0x05,           // = move BDAP entry
     OP_BDAP_ACCOUNT_ENTRY  = 0x06,       // = BDAP domain account entry (users and groups) 
@@ -677,6 +677,9 @@ public:
             break;
         case MINING_MODIFY_TX:
             return (size() > 0 && *begin() == OP_REWARD_MINING);
+            break;
+        case BDAP_REVOKE_TX:
+            return (size() > 0 && *begin() == OP_BDAP_REVOKE);
             break;
         default:
             throw std::runtime_error("Protocol code is invalid!");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2531,7 +2531,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
                         if (!DeleteDomainEntry(entry))
                             LogPrintf("%s -- Error deleting account %s\n", __func__, entry.GetFullObjectPath());
 
-                        CBanAccount banAccount(entry.vchFullObjectPath(), nTimeStamp, vSovereignAddresses, tx.GetHash(), pindex->nHeight);
+                        CBanAccount banAccount(scriptFluid, entry.vchFullObjectPath(), nTimeStamp, vSovereignAddresses, tx.GetHash(), pindex->nHeight);
                         AddBanAccountEntry(banAccount);
                     }
                 }


### PR DESCRIPTION
- Update fluid RPC `maketoken help` example output
- Remove `getrawpubkey` RPC command
- Add `banaccountstoken` RPC for revoking BDAP accounts with fluid
- Add ban BDAP account functionality with the `OP_BDAP_REVOKE` op code to consensus checking
- Do not allow unknown fluid operation codes in consensus checking
- Remove unused methods in fluid class `CFluid`
- Cleanup fluid code, remove unused comments and code
- Add missing pointer cleanup for Fluid, BDAP, and DHT objects in init
- Add fluid ban account to `getfluidhistoryraw`, `getfluidhistory` and `readfluidtoken` RPC
- Refactor sorting for `getfluidhistoryraw`, `getfluidhistory` and `readfluidtoken` RPC
* Not fully tested or reviewed. To fully test, all nodes must update on the privatenet testnet.