### PR TITLE
Add backwards compatibility for older wallets

### DIFF
--- a/src/bdap/rpcrawbdap.cpp
+++ b/src/bdap/rpcrawbdap.cpp
@@ -132,20 +132,30 @@ UniValue createrawbdapaccount(const JSONRPCRequest& request)
     scriptData << OP_RETURN << data;
 
     // Create script to fund link transaction for this account
-    CTxDestination destLinkAddress = DecodeDestination(sxAddr.ToString());
-    CScript scriptLinkDestination;
-    scriptLinkDestination = GetScriptForDestination(destLinkAddress);
+    CScript scriptDest;
+    std::vector<uint8_t> vStealthData;
+    std::string sError;
+    if (0 != PrepareStealthOutput(sxAddr, scriptDest, vStealthData, sError)) {
+        LogPrintf("%s -- PrepareStealthOutput failed. Error = %s\n", __func__, sError);
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Invalid stealth destination address %s", sxAddr.ToString()));
+    }  
+    CScript stealthScript;
+    stealthScript << OP_RETURN << vStealthData;
+
     // TODO (bdap): decrease this amount after BDAP fee structure is implemented.
     CAmount nLinkAmount(30 * COIN);
 
-    // Add the BDAP operation output
-    CTxOut outOP(nBDAPDeposit, scriptPubKey);
-    rawTx.vout.push_back(outOP);
+    // Add the Stealth OP return data
+    CTxOut outStealthData(0, stealthScript);
+    rawTx.vout.push_back(outStealthData);
     // Add the BDAP data output
     CTxOut outData(nBDAPRegistrationFee, scriptData);
     rawTx.vout.push_back(outData);
+    // Add the BDAP operation output
+    CTxOut outOP(nBDAPDeposit, scriptPubKey);
+    rawTx.vout.push_back(outOP);
     // Add the BDAP link funds output
-    CTxOut outLinkFunds(nLinkAmount, scriptLinkDestination);
+    CTxOut outLinkFunds(nLinkAmount, scriptDest);
     rawTx.vout.push_back(outLinkFunds);
 
     return EncodeHexTx(rawTx);

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -167,6 +167,18 @@ void AskPassphraseDialog::accept()
     } break;
     case UnlockMixing:
     case Unlock:
+        if (model->getWallet()->WalletNeedsUpgrading()) {
+            QMessageBox::StandardButton reply;
+            ui->buttonBox->clear();
+            ui->statuslabel->setText(tr("Rescanning... Please wait, this may take several minutes."));
+            reply = QMessageBox::question(this, QObject::tr("Confirm Additional Operations"), QObject::tr("The current wallet needs to be upgraded to a newer version. This will require the creation of new keys and a full rescan. This may take several minutes to complete. Continue?"), QMessageBox::Yes|QMessageBox::No);
+
+            if (reply == QMessageBox::No) {
+                QDialog::reject(); //cancel
+                break;
+            }
+        }
+
         if (!model->setWalletLocked(false, oldpass, mode == UnlockMixing)) {
             QMessageBox::critical(this, tr("Wallet unlock failed"),
                 tr("The passphrase entered for the wallet decryption was incorrect."));

--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -111,6 +111,13 @@
     </layout>
    </item>
    <item>
+    <widget class="QLabel" name="statuslabel">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -215,11 +215,9 @@ static UniValue getnewstealthaddress(const JSONRPCRequest &request)
 
     CPubKey walletPubKey;
     CStealthAddress sxAddr;
-    if (!pwalletMain->GetStealthAddressFromPool(walletPubKey, sxAddr, false))
+    std::vector<unsigned char> vchEd25519PubKey;
+    if (!pwalletMain->GetKeysFromPool(walletPubKey, vchEd25519PubKey, sxAddr, false))
         throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
-
-    if (!pwalletMain->AddStealthAddress(sxAddr))
-        throw std::runtime_error(strprintf("%s -- Failed to write stealth address to local wallet.\n", __func__));
 
     return sxAddr.ToString();
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -500,7 +500,7 @@ void SendBDAPTransaction(const CScript& bdapDataScript, const CScript& bdapOPScr
     }
 }
 
-void SendLinkingTransaction(const CScript& bdapDataScript, const CScript& bdapOPScript, const CScript& sendAddress, 
+void SendLinkingTransaction(const CScript& bdapDataScript, const CScript& bdapOPScript, const CScript& stealthScript, 
                                 CWalletTx& wtxNew, const CAmount& nOPValue, const CAmount& nDataValue, const bool fUseInstantSend)
 {
     CAmount curBalance = pwalletMain->GetBalance();
@@ -524,12 +524,16 @@ void SendLinkingTransaction(const CScript& bdapDataScript, const CScript& bdapOP
 
     if (nDataValue > 0) {
         CRecipient recDataScript = {bdapDataScript, 0, false};
-        vecSend.push_back(recDataScript);  
+        vecSend.push_back(recDataScript);
+        if (stealthScript.size() > 0) {
+            CRecipient sendStealthData = {stealthScript, 0, false};
+            vecSend.push_back(sendStealthData);
+            LogPrintf("Sending Stealth Script: %s\n", ScriptToAsmStr(stealthScript));
+        }
     }
-
     CRecipient recOPScript = {bdapOPScript, DEFAULT_MIN_RELAY_TX_FEE, false};
     vecSend.push_back(recOPScript);
-    // TODO (bdap) Make sure sendAddress is used to fund the transaction.
+    // TODO (BDAP) Make sure it uses privatesend funds
     if (!pwalletMain->CreateTransaction(vecSend, wtxNew, reservekey, nFeeRequired, nChangePosInOut,
             strError, NULL, true, ALL_COINS, fUseInstantSend, true)) {
         if (DEFAULT_MIN_RELAY_TX_FEE + nFeeRequired > pwalletMain->GetBalance())

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -582,10 +582,9 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool fForMixingOnl
                 continue; // try another master key
             if (CCryptoKeyStore::Unlock(vMasterKey, fForMixingOnly)) {
                 if (fNeedToUpgradeWallet) {
-                    LogPrintf("DEBUGGER WALLET %s - Made it to unlock portion\n", __func__);
                     if (SyncEdKeyPool()) {
                         SetMinVersion(FEATURE_HD);
-                        LogPrintf("DEBUGGER WALLET %s - Upgraded wallet\n", __func__);
+                        LogPrintf("%s - Upgraded wallet\n", __func__);
                     }
                 }
                 if (nWalletBackups == -2) {
@@ -608,10 +607,10 @@ bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool fForMixingOnl
             fNeedToUpgradeWallet = false;
             fNeedToUpdateKeyPools = true;
             fNeedToUpdateLinks = true;
-            LogPrintf("DEBUGGER WALLET %s - Rescanning transasctions\n", __func__);
+            LogPrintf("%s - Rescanning transasctions\n", __func__);
             pwalletMain->UpdateTimeFirstKey(1);
             pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
-            LogPrintf("DEBUGGER WALLET %s - Rescanning transasctions DONE\n", __func__);        
+            LogPrintf("%s - Rescanning transasctions DONE\n", __func__);        
         }
         return true;
     }
@@ -4501,8 +4500,6 @@ bool CWallet::SyncEdKeyPool()
     CPubKey retrievedPubKey2;
     CKey retrievedKey2;
 
-    LogPrintf("DEBUGGER WALLET %s - made it here!\n", __func__);
-
     for (int64_t nIndex : setInternalKeyPool) {
         if (!walletdb.ReadPool(nIndex, keypool)) {
             throw std::runtime_error(std::string(__func__) + ": read failed");
@@ -4525,8 +4522,6 @@ bool CWallet::SyncEdKeyPool()
                 LogPrintf("edkeypool added key %d, size=%u, internal=%d\n", nIndex, setInternalEdKeyPool.size() + setExternalEdKeyPool.size(), 1);
             }
         }
-        else
-            LogPrintf("DEBUGGER WALLET %s - internal edkey not added. already exists\n",__func__);
     }
 
     for (int64_t nIndex : setExternalKeyPool) {
@@ -4551,9 +4546,6 @@ bool CWallet::SyncEdKeyPool()
                 LogPrintf("edkeypool added key %d, size=%u, internal=%d\n", nIndex, setInternalEdKeyPool.size() + setExternalEdKeyPool.size(), 0);
             }
         }
-        else
-            LogPrintf("DEBUGGER WALLET %s - external edkey not added. already exists\n",__func__);
-
     }
 
     return true;
@@ -5724,32 +5716,23 @@ bool CWallet::InitLoadWallet()
     }
     pwalletMain = pwallet;
 
-    LogPrintf("DEBUGGER WALLET %s - wallet version [%d]\n", __func__,pwallet->GetVersion());
-
     if (pwallet->GetVersion() < FEATURE_HD) {
+        LogPrintf("%s - Older wallet version detected. Need to upgrade.\n", __func__);
         if (!pwalletMain->IsLocked()) {
             if (!pwallet->SyncEdKeyPool()) {
-                LogPrintf("DEBUGGER WALLET %s - SyncEdKeyPool is false\n", __func__);
+                LogPrintf("%s - ERROR: Unable to sync Ed25519 Keypool.\n", __func__);
             }
             else {
-                LogPrintf("DEBUGGER WALLET %s - SyncEdKeyPool is true\n", __func__);
-                LogPrintf("DEBUGGER WALLET %s - Upgrading wallet version\n", __func__);
+                LogPrintf("%s - Upgrading wallet version\n", __func__);
                 pwallet->SetMinVersion(FEATURE_HD);
                 pwallet->fNeedToUpgradeWallet = false;
-
-                LogPrintf("setExternalKeyPool.size() = %u\n", pwallet->KeypoolCountExternalKeys());
-                LogPrintf("setInternalKeyPool.size() = %u\n", pwallet->KeypoolCountInternalKeys());
-                LogPrintf("setExternalEdKeyPool.size() = %u\n", pwallet->EdKeypoolCountExternalKeys());
-                LogPrintf("setInternalEdKeyPool.size() = %u\n", pwallet->EdKeypoolCountInternalKeys());
             }
         }
         else {
-            LogPrintf("DEBUGGER WALLET %s - Upgrade wallet pending unlock\n", __func__);
+            LogPrintf("%s - Upgrade wallet pending unlock\n", __func__);
             pwallet->fNeedToUpgradeWallet = true; 
         }
-
     }
-
 
     ProcessLinkQueue(); // Process links in queue.
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -198,6 +198,25 @@ void CWallet::DeriveEd25519ChildKey(const CKey& seed, CKeyEd25519& secretEdRet)
 
 } //DeriveEd25519ChildKey
 
+bool CWallet::DeriveChildStealthKey(const CKey& key)
+{
+    CKey spendKey, scanKey;
+    if (!key.DeriveChildKey(spendKey))
+        return false;
+
+    if (!spendKey.DeriveChildKey(scanKey))
+        return false;
+
+    if (!AddKeyPubKey(spendKey, spendKey.GetPubKey()))
+        return false;
+
+    if (!AddKeyPubKey(scanKey, scanKey.GetPubKey()))
+        return false;
+
+    CStealthAddress sxAddr(scanKey, spendKey);
+    return AddStealthAddress(sxAddr);
+}
+
 void CWallet::DeriveNewChildKey(const CKeyMetadata& metadata, CKey& secretRet, uint32_t nAccountIndex, bool fInternal)
 {
     CHDChain hdChainTmp;
@@ -228,6 +247,7 @@ void CWallet::DeriveNewChildKey(const CKeyMetadata& metadata, CKey& secretRet, u
 
     CKeyEd25519 secretEdRet;
     DeriveEd25519ChildKey(secretRet,secretEdRet); //Derive Ed25519 key
+    DeriveChildStealthKey(secretRet);
 
     CPubKey pubkey = secretRet.GetPubKey();
     assert(secretRet.VerifyPubKey(pubkey));
@@ -4793,12 +4813,8 @@ void CWallet::ReturnKey(int64_t nIndex, bool fInternal)
     LogPrintf("keypool return %d\n", nIndex);
 }
 
-bool CWallet::GetStealthAddressFromPool(CPubKey& pubkeyWallet, CStealthAddress& sxAddr, bool fInternal)
+bool CWallet::GetKeysFromPool(CPubKey& pubkeyWallet, std::vector<unsigned char>& vchEd25519PubKey, CStealthAddress& sxAddr, bool fInternal)
 {
-    if (IsLocked())
-        return false;
-
-    std::vector<unsigned char> vchEd25519PubKey;
     if (!GetKeysFromPool(pubkeyWallet, vchEd25519PubKey, fInternal))
         return false;
 
@@ -4812,18 +4828,12 @@ bool CWallet::GetStealthAddressFromPool(CPubKey& pubkeyWallet, CStealthAddress& 
     if (!spendKey.DeriveChildKey(scanKey))
         return false;
 
-    if (!AddKeyPubKey(spendKey, spendKey.GetPubKey()))
-        return false;
-
-    if (!AddKeyPubKey(scanKey, scanKey.GetPubKey()))
-        return false;
-
     CStealthAddress sx(scanKey, spendKey);
     sxAddr = sx;
     return true;
 }
 
-bool CWallet::GetKeysFromPool(CPubKey& result, std::vector<unsigned char>& vchEd25519PubKey, bool fInternal)
+bool CWallet::GetKeysFromPool(CPubKey& pubkeyWallet, std::vector<unsigned char>& vchEd25519PubKey, bool fInternal)
 {
     int64_t nIndex = 0;
     int64_t nEdIndex = 0;
@@ -4837,15 +4847,15 @@ bool CWallet::GetKeysFromPool(CPubKey& result, std::vector<unsigned char>& vchEd
             if (IsLocked(true))
                 return false;
             // TODO: implement keypool for all accouts?
-            result = GenerateNewKey(0, fInternal);
+            pubkeyWallet = GenerateNewKey(0, fInternal);
         }
         else {
             KeepKey(nIndex);
-            result = keypool.vchPubKey;
+            pubkeyWallet = keypool.vchPubKey;
         }
 
         CKey keyRetrieved;
-        GetKey(result.GetID(), keyRetrieved);
+        GetKey(pubkeyWallet.GetID(), keyRetrieved);
 
         if (nEdIndex == -1) {
             if (IsLocked(true))
@@ -6086,7 +6096,6 @@ bool CWallet::ScanForOwnedOutputs(const CTransaction& tx)
 
 bool CWallet::AddStealthAddress(const CStealthAddress& sxAddr)
 {
-    LogPrintf("%s: %s\n", __func__, sxAddr.Encoded());
     CWalletDB* pwdb = GetWalletDB();
 
     LOCK(cs_mapStealthAddresses);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -755,6 +755,7 @@ private:
 
     bool fNeedToUpdateKeyPools = false;
     bool fNeedToUpdateLinks = false;
+    bool fNeedToUpgradeWallet = false;
 
     mutable bool fAnonymizableTallyCached;
     mutable std::vector<CompactTallyItem> vecAnonymizableTallyCached;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -825,6 +825,11 @@ public:
 
     const std::string strWalletFile;
 
+    bool WalletNeedsUpgrading()
+    {
+        return fNeedToUpgradeWallet;
+    }
+
     void LoadKeyPool(int nIndex, const CKeyPool& keypool)
     {
         if (keypool.fInternal) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -780,6 +780,9 @@ private:
 
     void DeriveEd25519ChildKey(const CKey& seed, CKeyEd25519& secretEdRet);
 
+    /* HD derive new child stealth key from  */
+    bool DeriveChildStealthKey(const CKey& key);
+
     void ReserveEdKeyFromKeyPool(int64_t& nIndex, CEdKeyPool& edkeypool, bool fInternal);    
 
     void ReserveEdKeyForTransactions();    
@@ -1137,7 +1140,8 @@ public:
     void KeepKey(int64_t nIndex);
     void KeepEdKey(int64_t nIndex);
     void ReturnKey(int64_t nIndex, bool fInternal);
-    bool GetKeysFromPool(CPubKey& result, std::vector<unsigned char>& vchEd25519PubKey, bool fInternal);
+    bool GetKeysFromPool(CPubKey& pubkeyWallet, std::vector<unsigned char>& vchEd25519PubKey, bool fInternal);
+    bool GetKeysFromPool(CPubKey& pubkeyWallet, std::vector<unsigned char>& vchEd25519PubKey, CStealthAddress& sxAddr, bool fInternal);
     int64_t GetOldestKeyPoolTime();
     void GetAllReserveKeys(std::set<CKeyID>& setAddress) const;
     void UpdateKeyPoolsFromTransactions(const std::string& strOpType, const std::vector<std::vector<unsigned char>>& vvchOpParameters);
@@ -1307,7 +1311,6 @@ public:
     bool AddToStealthQueue(const std::pair<CKeyID, CStealthKeyQueueData>& pairStealthQueue);
     CWalletDB* GetWalletDB();
     bool HaveStealthAddress(const CKeyID& address) const;
-    bool GetStealthAddressFromPool(CPubKey& pubkeyWallet, CStealthAddress& sxAddr, bool fInternal);
 
 };
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1133,6 +1133,7 @@ public:
     size_t KeypoolCountInternalKeys();
     size_t EdKeypoolCountExternalKeys();
     size_t EdKeypoolCountInternalKeys();
+    bool SyncEdKeyPool(); 
     bool TopUpKeyPool(unsigned int kpSize = 0);
     bool TopUpEdKeyPool(unsigned int kpSize = 0); 
     bool TopUpKeyPoolCombo(unsigned int kpSize = 0);       

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -658,7 +658,6 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             ssKey >> keyID;
             CStealthAddress sxAddr;
             ssValue >> sxAddr;
-            LogPrintf("%s -- AddStealthToMap \n", __func__);
             pwallet->AddStealthToMap(std::make_pair(keyID, sxAddr));
 
         } else if (strType == "sxqueue") {
@@ -666,7 +665,6 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             ssKey >> keyID;
             CStealthKeyQueueData stealthData;
             ssValue >> stealthData;
-            LogPrintf("%s -- AddToStealthQueue \n", __func__);
             pwallet->AddToStealthQueue(std::make_pair(keyID, stealthData));
 
         }


### PR DESCRIPTION
- Add ability to upgrade wallet with corresponding Ed25519 keys if an older version is detected
- Add ability to upgrade older wallet that is locked. Defer upgrade until unlocked
- During unlock, add confirmation popup to GUI that older locked wallet needs to be upgraded and rescan done
- Merge StealthLink2 changes