### PR TITLE
BDAP GUI & RPC and logging updates

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -59,6 +59,7 @@ QT_MOC_CPP = \
   qt/moc_bdapaccounttablemodel.cpp \
   qt/moc_bdapaddlinkdialog.cpp \
   qt/moc_bdapadduserdialog.cpp \
+  qt/moc_bdapfeespopup.cpp \
   qt/moc_bdaplinkdetaildialog.cpp \
   qt/moc_bdaplinktablemodel.cpp \
   qt/moc_bdappage.cpp \
@@ -139,6 +140,7 @@ DYNAMIC_QT_H = \
   qt/bdapaccounttablemodel.h \
   qt/bdapaddlinkdialog.h \
   qt/bdapadduserdialog.h \
+  qt/bdapfeespopup.h \
   qt/bdaplinkdetaildialog.h \
   qt/bdaplinktablemodel.h \
   qt/bdappage.h \
@@ -308,6 +310,7 @@ DYNAMIC_QT_CPP += \
   qt/askpassphrasedialog.cpp \
   qt/bdapaddlinkdialog.cpp \
   qt/bdapadduserdialog.cpp \
+  qt/bdapfeespopup.cpp \
   qt/bdaplinkdetaildialog.cpp \
   qt/bdappage.cpp \
   qt/bdapupdateaccountdialog.cpp \

--- a/src/bdap/domainentrydb.h
+++ b/src/bdap/domainentrydb.h
@@ -34,7 +34,7 @@ public:
     void WriteDomainEntryIndexHistory(const CDomainEntry& entry, const int op);
     bool UpdateDomainEntry(const std::vector<unsigned char>& vchObjectPath, const CDomainEntry& entry);
     bool CleanupLevelDB(int& nRemoved);
-    bool ListDirectories(const std::vector<unsigned char>& vchObjectLocation, const unsigned int& nResultsPerPage, const unsigned int& nPage, UniValue& oDomainEntryList, const BDAP::ObjectType& accountType = DEFAULT_ACCOUNT_TYPE);
+    bool ListDirectories(const std::vector<unsigned char>& vchObjectLocation, const unsigned int& nResultsPerPage, const unsigned int& nPage, UniValue& oDomainEntryList, const BDAP::ObjectType& accountType = DEFAULT_ACCOUNT_TYPE, const std::string searchString = "");
     bool GetDomainEntryInfo(const std::vector<unsigned char>& vchFullObjectPath, UniValue& oDomainEntryInfo);
     bool GetDomainEntryInfo(const std::vector<unsigned char>& vchFullObjectPath, CDomainEntry& entry);
 };

--- a/src/bdap/rpcdomainentry.cpp
+++ b/src/bdap/rpcdomainentry.cpp
@@ -72,7 +72,9 @@ static UniValue AddDomainEntry(const JSONRPCRequest& request, BDAP::ObjectType b
     int32_t nMonths = DEFAULT_REGISTRATION_MONTHS; // default to 2 years.
     if (request.params.size() >= 3) {
         if (!ParseInt32(request.params[2].get_str(), &nMonths))
-            throw std::runtime_error("BDAP_ADD_PUBLIC_ENTRY_RPC_ERROR: ERRCODE: 3505 - " + _("Error converting registration days to int"));
+            throw std::runtime_error("BDAP_ADD_PUBLIC_ENTRY_RPC_ERROR: ERRCODE: 3505 - " + _("Error converting registration months to int, only whole numbers allowed (no decimals)"));
+        if (nMonths <= 0)
+            throw std::runtime_error("BDAP_ADD_PUBLIC_ENTRY_RPC_ERROR: ERRCODE: 3505 - " + _("Error: registration months must be greater than 0"));
     }
 
     CharString data;

--- a/src/bdap/rpcdomainentry.cpp
+++ b/src/bdap/rpcdomainentry.cpp
@@ -185,12 +185,13 @@ UniValue adduser(const JSONRPCRequest& request)
 
 UniValue getusers(const JSONRPCRequest& request) 
 {
-    if (request.fHelp || request.params.size() > 2)
+    if (request.fHelp || request.params.size() > 3 || request.params.size() == 2)
         throw std::runtime_error(
-            "getusers \"records per page\" \"page returned\"\n"
+            "getusers \"search string\" \"records per page\" \"page returned\"\n"
             "\nArguments:\n"
-            "1. records per page     (int, optional)  If paging, the number of records per page\n"
-            "2. page returned        (int, optional)  If paging, the page number to return\n"
+            "1. search string        (string, optional)  Search for userid\n"
+            "2. records per page     (int, optional)  If paging, the number of records per page\n"
+            "3. page returned        (int, optional)  If paging, the page number to return\n"
             "\nLists all BDAP user accounts in the \"public\" OU for the \"bdap.io\" domain.\n"
             "\nResult:\n"
             "{(json objects)\n"
@@ -204,13 +205,31 @@ UniValue getusers(const JSONRPCRequest& request)
            "\nAs a JSON-RPC call\n" + 
            HelpExampleRpc("getusers", ""));
 
-    unsigned int nRecordsPerPage = 100;
-    unsigned int nPage = 1;
-    if (request.params.size() > 0)
-        nRecordsPerPage = request.params[0].get_int();
+    int nRecordsPerPage = 100;
+    int nPage = 1;
+    std::string searchString = "";
 
-    if (request.params.size() == 2)
-        nPage = request.params[1].get_int();
+    if (request.params.size() > 0)
+    {
+         searchString = request.params[0].get_str();
+    }
+
+    if (request.params.size() == 3)
+    {
+        try {
+            nRecordsPerPage = atoi(request.params[1].get_str());
+            nPage = atoi(request.params[2].get_str());
+
+            if ((nRecordsPerPage <= 0) || (nPage <= 0))
+            {
+                throw std::runtime_error("Error: parameters must be positive integers");
+                return NullUniValue;
+            }       
+        } catch (std::exception& e) {
+            throw std::runtime_error("Error: parameters must be positive integers");
+            return NullUniValue;
+        }
+    }
     
     // only return entries from the default public domain OU
     std::string strObjectLocation = DEFAULT_PUBLIC_OU + "." + DEFAULT_PUBLIC_DOMAIN;
@@ -218,19 +237,20 @@ UniValue getusers(const JSONRPCRequest& request)
 
     UniValue oDomainEntryList(UniValue::VARR);
     if (CheckDomainEntryDB())
-        pDomainEntryDB->ListDirectories(vchObjectLocation, nRecordsPerPage, nPage, oDomainEntryList, BDAP::ObjectType::BDAP_USER);
+        pDomainEntryDB->ListDirectories(vchObjectLocation, nRecordsPerPage, nPage, oDomainEntryList, BDAP::ObjectType::BDAP_USER, searchString);
 
     return oDomainEntryList;
 }
 
 UniValue getgroups(const JSONRPCRequest& request) 
 {
-    if (request.fHelp || request.params.size() > 2)
+    if (request.fHelp || request.params.size() > 3 || request.params.size() == 2)
         throw std::runtime_error(
-            "getgroups \"records per page\" \"page returned\"\n"
+            "getgroups \"search string\" \"records per page\" \"page returned\"\n"
             "\nArguments:\n"
-            "1. records per page     (int, optional)  If paging, the number of records per page\n"
-            "2. page returned        (int, optional)  If paging, the page number to return\n"
+            "1. search string        (string, optional)  Search for userid\n"
+            "2. records per page     (int, optional)  If paging, the number of records per page\n"
+            "3. page returned        (int, optional)  If paging, the page number to return\n"
             "\nLists all BDAP group accounts in the \"public\" OU for the \"bdap.io\" domain.\n"
             "\nResult:\n"
             "{(json objects)\n"
@@ -244,13 +264,31 @@ UniValue getgroups(const JSONRPCRequest& request)
            "\nAs a JSON-RPC call\n" + 
            HelpExampleRpc("getgroups", ""));
 
-    unsigned int nRecordsPerPage = 100;
-    unsigned int nPage = 1;
-    if (request.params.size() > 0)
-        nRecordsPerPage = request.params[0].get_int();
+    int nRecordsPerPage = 100;
+    int nPage = 1;
+    std::string searchString = "";
 
-    if (request.params.size() == 2)
-        nPage = request.params[1].get_int();
+    if (request.params.size() > 0)
+    {
+         searchString = request.params[0].get_str();
+    }
+
+    if (request.params.size() == 3)
+    {
+        try {
+            nRecordsPerPage = atoi(request.params[1].get_str());
+            nPage = atoi(request.params[2].get_str());
+
+            if ((nRecordsPerPage <= 0) || (nPage <= 0))
+            {
+                throw std::runtime_error("Error: parameters must be positive integers");
+                return NullUniValue;
+            }       
+        } catch (std::exception& e) {
+            throw std::runtime_error("Error: parameters must be positive integers");
+            return NullUniValue;
+        }
+    }
     
     // only return entries from the default public domain OU
     std::string strObjectLocation = DEFAULT_PUBLIC_OU + "." + DEFAULT_PUBLIC_DOMAIN;
@@ -258,7 +296,7 @@ UniValue getgroups(const JSONRPCRequest& request)
 
     UniValue oDomainEntryList(UniValue::VARR);
     if (CheckDomainEntryDB())
-        pDomainEntryDB->ListDirectories(vchObjectLocation, nRecordsPerPage, nPage, oDomainEntryList, BDAP::ObjectType::BDAP_GROUP);
+        pDomainEntryDB->ListDirectories(vchObjectLocation, nRecordsPerPage, nPage, oDomainEntryList, BDAP::ObjectType::BDAP_GROUP, searchString);
 
     return oDomainEntryList;
 }
@@ -889,8 +927,8 @@ static const CRPCCommand commands[] =
 #ifdef ENABLE_WALLET
     /* BDAP */
     { "bdap",            "adduser",                  &adduser,                      true, {"account id", "common name", "registration days"} },
-    { "bdap",            "getusers",                 &getusers,                     true, {"records per page", "page returned"} },
-    { "bdap",            "getgroups",                &getgroups,                    true, {"records per page", "page returned"} },
+    { "bdap",            "getusers",                 &getusers,                     true, {"search string", "records per page", "page returned"} },
+    { "bdap",            "getgroups",                &getgroups,                    true, {"search string", "records per page", "page returned"} },
     { "bdap",            "getuserinfo",              &getuserinfo,                  true, {"account id"} },
     { "bdap",            "updateuser",               &updateuser,                   true, {"account id", "common name", "registration days"} },
     { "bdap",            "updategroup",              &updategroup,                  true, {"account id", "common name", "registration days"} },

--- a/src/qt/bdapaccounttablemodel.cpp
+++ b/src/qt/bdapaccounttablemodel.cpp
@@ -194,12 +194,13 @@ BdapAccountTableModel::BdapAccountTableModel(BdapPage* parent) : QAbstractTableM
     refreshUsers();
     refreshGroups();
 
-    //refresh();
+    //comment out timer, but keep for possible future use
+    /*
     timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), SLOT(refresh()));
     timer->setInterval(60000); //MODEL_UPDATE_DELAY originally
     startAutoRefresh();
-
+    */
 }
 
 BdapAccountTableModel::~BdapAccountTableModel()

--- a/src/qt/bdapaddlinkdialog.cpp
+++ b/src/qt/bdapaddlinkdialog.cpp
@@ -3,18 +3,20 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "bdapaddlinkdialog.h"
-#include "ui_bdapaddlinkdialog.h"
+#include "bdapfeespopup.h"
 #include "bdaplinkdetaildialog.h"
 #include "bdappage.h"
+#include "ui_bdapaddlinkdialog.h"
 
+#include "bdap/fees.h"
 #include "guiutil.h"
 #include "rpcregister.h"
 #include "rpcserver.h"
 #include "rpcclient.h"
 #include "util.h"
 
-#include <stdio.h>
 #include <boost/algorithm/string.hpp>
+#include <stdio.h>
 
 BdapAddLinkDialog::BdapAddLinkDialog(QWidget *parent) : QDialog(parent),
                                                         ui(new Ui::BdapAddLinkDialog)
@@ -39,7 +41,6 @@ BdapAddLinkDialog::BdapAddLinkDialog(QWidget *parent) : QDialog(parent),
     autoCompleterFrom = new QCompleter(fromList, this);
     ui->lineEditRequestor->setCompleter(autoCompleterFrom);
     autoCompleterFrom->popup()->installEventFilter(this);
-
 
     //setup autocomplete for TO input
     populateList(accountListTo,LinkUserType::LINK_RECIPIENT);
@@ -131,6 +132,11 @@ void BdapAddLinkDialog::addLink()
         QMessageBox::critical(this, "BDAP Add Link Error", QObject::tr("Requestor, Recipient and Link Message are required fields"));
         return;
     } //if requestor
+
+    if (!bdapFeesPopup(this,OP_BDAP_NEW,OP_BDAP_LINK_REQUEST,BDAP::ObjectType::BDAP_LINK_REQUEST)) {
+        goClose();
+        return;
+    }
 
     params.push_back("request");
     params.push_back(requestor);

--- a/src/qt/bdapadduserdialog.cpp
+++ b/src/qt/bdapadduserdialog.cpp
@@ -61,6 +61,22 @@ void BdapAddUserDialog::goAddUser()
     accountID = ui->lineEdit_userID->text().toStdString();
     commonName = ui->lineEdit_commonName->text().toStdString();
     registrationMonths = ui->lineEdit_registrationMonths->text().toStdString();
+    
+    if (registrationMonths.length() >> 0) 
+    {
+        try {
+            regMonths = std::stoi(registrationMonths);
+        } catch (std::exception& e) {
+            QMessageBox::critical(this, QObject::tr("BDAP Error"),QObject::tr("Registration months must be a number."));
+            return;
+        }
+
+        CAmount tmpAmount;
+        if ( (!ParseFixedPoint(registrationMonths, 0, &tmpAmount)) || (regMonths <= 0) ) {
+            QMessageBox::critical(this, QObject::tr("BDAP Error"),QObject::tr("Registration months cannot be less than or equal to zero, and must be a whole number (no decimals)."));
+            return;
+        }
+    }
 
     ui->lineEdit_userID->setReadOnly(true);
     ui->lineEdit_commonName->setReadOnly(true);
@@ -77,8 +93,6 @@ void BdapAddUserDialog::goAddUser()
 
     ui->addUser->setVisible(false);
     ui->cancel->setVisible(false);
-    
-    if (registrationMonths.length() >> 0) regMonths = std::stoi(registrationMonths);
 
     if (!bdapFeesPopup(this,OP_BDAP_NEW,OP_BDAP_ACCOUNT_ENTRY,inputAccountType,regMonths)) {
         goClose();
@@ -87,7 +101,7 @@ void BdapAddUserDialog::goAddUser()
 
     params.push_back(accountID);
     params.push_back(commonName);
-    if (registrationMonths.length() >> 0) params.push_back(registrationMonths);
+    if (registrationMonths.length() >> 0) params.push_back(std::to_string(regMonths));
 
     if (inputAccountType == BDAP::ObjectType::BDAP_USER) {
         jreq.params = RPCConvertValues("adduser", params);

--- a/src/qt/bdapadduserdialog.h
+++ b/src/qt/bdapadduserdialog.h
@@ -5,11 +5,11 @@
 #ifndef BDAPADDUSERDIALOG_H
 #define BDAPADDUSERDIALOG_H
 
-#include "platformstyle.h"
 #include "bdap/bdap.h"
+#include "platformstyle.h"
 
-#include <QPushButton>
 #include <QDialog>
+#include <QPushButton>
 
 #include <memory>
 

--- a/src/qt/bdapfeespopup.cpp
+++ b/src/qt/bdapfeespopup.cpp
@@ -4,8 +4,9 @@
 
 #include "bdapfeespopup.h"
 #include "dynamicunits.h"
+#include "wallet/wallet.h"
 
-bool bdapFeesPopup(QDialog *parentDialog, const opcodetype& opCodeAction, const opcodetype& opCodeObject, BDAP::ObjectType inputAccountType, int32_t regMonths)
+bool bdapFeesPopup(QWidget *parentDialog, const opcodetype& opCodeAction, const opcodetype& opCodeObject, BDAP::ObjectType inputAccountType, int32_t regMonths)
 {
     QMessageBox::StandardButton reply;
     QString questionString = QObject::tr("Are you sure you want to add/modify BDAP object?<br />");
@@ -18,6 +19,7 @@ bool bdapFeesPopup(QDialog *parentDialog, const opcodetype& opCodeAction, const 
     CAmount totalAmount;
     DynamicUnits::Unit u;
     bool displayMonths = false;
+    CAmount currBalance = pwalletMain->GetBalance();
 
     //only display months for BDAP objects/transactions that include it. may need to expand in the future
     if ( (opCodeAction == OP_BDAP_NEW && opCodeObject == OP_BDAP_ACCOUNT_ENTRY) && ( inputAccountType == BDAP::ObjectType::BDAP_USER || inputAccountType == BDAP::ObjectType::BDAP_GROUP ) )
@@ -31,8 +33,15 @@ bool bdapFeesPopup(QDialog *parentDialog, const opcodetype& opCodeAction, const 
 
     totalAmount = monthlyFee + oneTimeFee + depositFee;
 
+    if (totalAmount > currBalance)
+    {
+        QMessageBox::critical(parentDialog, QObject::tr("BDAP Transaction"), QObject::tr("The amount exceeds your balance."));
+        return false;
+    }
+
     questionString.append(QObject::tr("<b>%1</b> will be withdrawn from any available funds (not anonymous).<br />") .arg(DynamicUnits::formatHtmlWithUnit(u, totalAmount)));
     questionString.append(QObject::tr("<hr>"));
+    //questionString.append(QObject::tr("Current balance = <b>%1</b><br />") .arg(DynamicUnits::formatHtmlWithUnit(u, currBalance)));
     questionString.append(QObject::tr("Total amount = <b>%1</b><br />") .arg(DynamicUnits::formatHtmlWithUnit(u, totalAmount)));
     questionString.append(QObject::tr("Monthly fee = %1" ) .arg(DynamicUnits::formatHtmlWithUnit(u, monthlyFee)));
     if (displayMonths)
@@ -54,51 +63,3 @@ bool bdapFeesPopup(QDialog *parentDialog, const opcodetype& opCodeAction, const 
 
 } //bdapFeesPopup
 
-bool bdapFeesPopup(BdapPage *parentDialog, const opcodetype& opCodeAction, const opcodetype& opCodeObject, BDAP::ObjectType inputAccountType, int32_t regMonths)
-{
-    QMessageBox::StandardButton reply;
-    QString questionString = QObject::tr("Are you sure you want to add/modify BDAP object?<br />");
-
-    questionString.append(QObject::tr("<br /><br />"));
-
-    CAmount monthlyFee; 
-    CAmount oneTimeFee;
-    CAmount depositFee;
-    CAmount totalAmount;
-    DynamicUnits::Unit u;
-    bool displayMonths = false;
-
-    //only display months for BDAP objects/transactions that include it. may need to expand in the future
-    if ( (opCodeAction == OP_BDAP_NEW && opCodeObject == OP_BDAP_ACCOUNT_ENTRY) && ( inputAccountType == BDAP::ObjectType::BDAP_USER || inputAccountType == BDAP::ObjectType::BDAP_GROUP ) )
-        displayMonths = true;
-
-    if (!GetBDAPFees(opCodeAction,opCodeObject,inputAccountType,regMonths,monthlyFee,oneTimeFee,depositFee))
-    {
-        QMessageBox::critical(0, QObject::tr("Error calculating fees"),QObject::tr("Cannot calculate fees at this time."));
-        return false;
-    }
-
-    totalAmount = monthlyFee + oneTimeFee + depositFee;
-
-    questionString.append(QObject::tr("<b>%1</b> will be withdrawn from any available funds (not anonymous).<br />") .arg(DynamicUnits::formatHtmlWithUnit(u, totalAmount)));
-    questionString.append(QObject::tr("<hr>"));
-    questionString.append(QObject::tr("Total amount = <b>%1</b><br />") .arg(DynamicUnits::formatHtmlWithUnit(u, totalAmount)));
-    questionString.append(QObject::tr("Monthly fee = %1" ) .arg(DynamicUnits::formatHtmlWithUnit(u, monthlyFee)));
-    if (displayMonths)
-        questionString.append(QObject::tr("&nbsp;(for %1 months)") .arg(regMonths));
-    questionString.append(QObject::tr("<br />"));
-    questionString.append(QObject::tr("One Time Fee = %1<br />") .arg(DynamicUnits::formatHtmlWithUnit(u, oneTimeFee)));
-    questionString.append(QObject::tr("Deposit Fee = %1") .arg(DynamicUnits::formatHtmlWithUnit(u, depositFee)));
-    questionString.append(QObject::tr("<hr>"));
-    questionString.append(QObject::tr("<br><span style='color:#aa0000;'><b>Note:</b></span> Total Amount does not include transaction fee (to be removed in the future)."));
-
-    reply = QMessageBox::question(parentDialog, QObject::tr("Confirm BDAP Transaction Amount"), questionString, QMessageBox::Yes|QMessageBox::No);
-
-    if (reply == QMessageBox::Yes) {
-        return true;
-    }
-    else {
-        return false;
-    }
-
-} //bdapFeesPopup overload

--- a/src/qt/bdapfeespopup.cpp
+++ b/src/qt/bdapfeespopup.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2019 Duality Blockchain Solutions Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bdapfeespopup.h"
+#include "dynamicunits.h"
+
+bool bdapFeesPopup(QDialog *parentDialog, const opcodetype& opCodeAction, const opcodetype& opCodeObject, BDAP::ObjectType inputAccountType, int32_t regMonths)
+{
+    QMessageBox::StandardButton reply;
+    QString questionString = QObject::tr("Are you sure you want to add/modify BDAP object?<br />");
+
+    questionString.append(QObject::tr("<br /><br />"));
+
+    CAmount monthlyFee; 
+    CAmount oneTimeFee;
+    CAmount depositFee;
+    CAmount totalAmount;
+    DynamicUnits::Unit u;
+    bool displayMonths = false;
+
+    //only display months for BDAP objects/transactions that include it. may need to expand in the future
+    if ( (opCodeAction == OP_BDAP_NEW && opCodeObject == OP_BDAP_ACCOUNT_ENTRY) && ( inputAccountType == BDAP::ObjectType::BDAP_USER || inputAccountType == BDAP::ObjectType::BDAP_GROUP ) )
+        displayMonths = true;
+
+    if (!GetBDAPFees(opCodeAction,opCodeObject,inputAccountType,regMonths,monthlyFee,oneTimeFee,depositFee))
+    {
+        QMessageBox::critical(0, QObject::tr("Error calculating fees"),QObject::tr("Cannot calculate fees at this time."));
+        return false;
+    }
+
+    totalAmount = monthlyFee + oneTimeFee + depositFee;
+
+    questionString.append(QObject::tr("<b>%1</b> will be withdrawn from any available funds (not anonymous).<br />") .arg(DynamicUnits::formatHtmlWithUnit(u, totalAmount)));
+    questionString.append(QObject::tr("<hr>"));
+    questionString.append(QObject::tr("Total amount = <b>%1</b><br />") .arg(DynamicUnits::formatHtmlWithUnit(u, totalAmount)));
+    questionString.append(QObject::tr("Monthly fee = %1" ) .arg(DynamicUnits::formatHtmlWithUnit(u, monthlyFee)));
+    if (displayMonths)
+        questionString.append(QObject::tr("&nbsp;(for %1 months)") .arg(regMonths));
+    questionString.append(QObject::tr("<br />"));
+    questionString.append(QObject::tr("One Time Fee = %1<br />") .arg(DynamicUnits::formatHtmlWithUnit(u, oneTimeFee)));
+    questionString.append(QObject::tr("Deposit Fee = %1") .arg(DynamicUnits::formatHtmlWithUnit(u, depositFee)));
+    questionString.append(QObject::tr("<hr>"));
+    questionString.append(QObject::tr("<br><span style='color:#aa0000;'><b>Note:</b></span> Total Amount does not include transaction fee (to be removed in the future)."));
+
+    reply = QMessageBox::question(parentDialog, QObject::tr("Confirm BDAP Transaction Amount"), questionString, QMessageBox::Yes|QMessageBox::No);
+
+    if (reply == QMessageBox::Yes) {
+        return true;
+    }
+    else {
+        return false;
+    }
+
+} //bdapFeesPopup
+
+bool bdapFeesPopup(BdapPage *parentDialog, const opcodetype& opCodeAction, const opcodetype& opCodeObject, BDAP::ObjectType inputAccountType, int32_t regMonths)
+{
+    QMessageBox::StandardButton reply;
+    QString questionString = QObject::tr("Are you sure you want to add/modify BDAP object?<br />");
+
+    questionString.append(QObject::tr("<br /><br />"));
+
+    CAmount monthlyFee; 
+    CAmount oneTimeFee;
+    CAmount depositFee;
+    CAmount totalAmount;
+    DynamicUnits::Unit u;
+    bool displayMonths = false;
+
+    //only display months for BDAP objects/transactions that include it. may need to expand in the future
+    if ( (opCodeAction == OP_BDAP_NEW && opCodeObject == OP_BDAP_ACCOUNT_ENTRY) && ( inputAccountType == BDAP::ObjectType::BDAP_USER || inputAccountType == BDAP::ObjectType::BDAP_GROUP ) )
+        displayMonths = true;
+
+    if (!GetBDAPFees(opCodeAction,opCodeObject,inputAccountType,regMonths,monthlyFee,oneTimeFee,depositFee))
+    {
+        QMessageBox::critical(0, QObject::tr("Error calculating fees"),QObject::tr("Cannot calculate fees at this time."));
+        return false;
+    }
+
+    totalAmount = monthlyFee + oneTimeFee + depositFee;
+
+    questionString.append(QObject::tr("<b>%1</b> will be withdrawn from any available funds (not anonymous).<br />") .arg(DynamicUnits::formatHtmlWithUnit(u, totalAmount)));
+    questionString.append(QObject::tr("<hr>"));
+    questionString.append(QObject::tr("Total amount = <b>%1</b><br />") .arg(DynamicUnits::formatHtmlWithUnit(u, totalAmount)));
+    questionString.append(QObject::tr("Monthly fee = %1" ) .arg(DynamicUnits::formatHtmlWithUnit(u, monthlyFee)));
+    if (displayMonths)
+        questionString.append(QObject::tr("&nbsp;(for %1 months)") .arg(regMonths));
+    questionString.append(QObject::tr("<br />"));
+    questionString.append(QObject::tr("One Time Fee = %1<br />") .arg(DynamicUnits::formatHtmlWithUnit(u, oneTimeFee)));
+    questionString.append(QObject::tr("Deposit Fee = %1") .arg(DynamicUnits::formatHtmlWithUnit(u, depositFee)));
+    questionString.append(QObject::tr("<hr>"));
+    questionString.append(QObject::tr("<br><span style='color:#aa0000;'><b>Note:</b></span> Total Amount does not include transaction fee (to be removed in the future)."));
+
+    reply = QMessageBox::question(parentDialog, QObject::tr("Confirm BDAP Transaction Amount"), questionString, QMessageBox::Yes|QMessageBox::No);
+
+    if (reply == QMessageBox::Yes) {
+        return true;
+    }
+    else {
+        return false;
+    }
+
+} //bdapFeesPopup overload

--- a/src/qt/bdapfeespopup.h
+++ b/src/qt/bdapfeespopup.h
@@ -14,7 +14,6 @@
 #include <QPushButton>
 #include <QTranslator>
 
-bool bdapFeesPopup(QDialog *parentDialog, const opcodetype& opCodeAction, const opcodetype& opCodeObject, BDAP::ObjectType inputAccountType = BDAP::ObjectType::BDAP_USER, int32_t regMonths = DEFAULT_REGISTRATION_MONTHS);
-bool bdapFeesPopup(BdapPage *parentDialog, const opcodetype& opCodeAction, const opcodetype& opCodeObject, BDAP::ObjectType inputAccountType = BDAP::ObjectType::BDAP_USER, int32_t regMonths = DEFAULT_REGISTRATION_MONTHS);
+bool bdapFeesPopup(QWidget *parentDialog, const opcodetype& opCodeAction, const opcodetype& opCodeObject, BDAP::ObjectType inputAccountType = BDAP::ObjectType::BDAP_USER, int32_t regMonths = DEFAULT_REGISTRATION_MONTHS);
 
 #endif // DYNAMIC_QT_BDAPFEESPOPUP_H

--- a/src/qt/bdapfeespopup.h
+++ b/src/qt/bdapfeespopup.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2019 Duality Blockchain Solutions Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DYNAMIC_QT_BDAPFEESPOPUP_H
+#define DYNAMIC_QT_BDAPFEESPOPUP_H
+
+#include "bdap/fees.h"
+#include "bdappage.h"
+
+#include <QDialog>
+#include <QMessageBox>
+#include <QObject>
+#include <QPushButton>
+#include <QTranslator>
+
+bool bdapFeesPopup(QDialog *parentDialog, const opcodetype& opCodeAction, const opcodetype& opCodeObject, BDAP::ObjectType inputAccountType = BDAP::ObjectType::BDAP_USER, int32_t regMonths = DEFAULT_REGISTRATION_MONTHS);
+bool bdapFeesPopup(BdapPage *parentDialog, const opcodetype& opCodeAction, const opcodetype& opCodeObject, BDAP::ObjectType inputAccountType = BDAP::ObjectType::BDAP_USER, int32_t regMonths = DEFAULT_REGISTRATION_MONTHS);
+
+#endif // DYNAMIC_QT_BDAPFEESPOPUP_H

--- a/src/qt/bdaplinktablemodel.cpp
+++ b/src/qt/bdaplinktablemodel.cpp
@@ -209,13 +209,15 @@ BdapLinkTableModel::BdapLinkTableModel(BdapPage* parent) : QAbstractTableModel(p
     // default to unsorted
     priv->sortColumn = -1;
 
-    //initialize tables the first time
     refreshAll();
 
+    //comment out timer, but keep for possible future use
+    /*
     timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), SLOT(refresh()));
     timer->setInterval(60000); //MODEL_UPDATE_DELAY originally 
     startAutoRefresh();  
+    */
 
 }
 

--- a/src/qt/bdappage.cpp
+++ b/src/qt/bdappage.cpp
@@ -12,6 +12,7 @@
 #include "bdappage.h"
 #include "bdapupdateaccountdialog.h"
 #include "bdapuserdetaildialog.h"
+#include "clientmodel.h"
 #include "dynode-sync.h"
 #include "guiutil.h"
 #include "rpcclient.h"
@@ -28,6 +29,8 @@
 
 BdapPage::BdapPage(const PlatformStyle* platformStyle, QWidget* parent) : QWidget(parent),
                                                                             ui(new Ui::BdapPage),
+                                                                            clientModel(0),
+                                                                            model(0),
                                                                             bdapAccountTableModel(0)
 {
     ui->setupUi(this);
@@ -91,6 +94,7 @@ BdapPage::BdapPage(const PlatformStyle* platformStyle, QWidget* parent) : QWidge
     connect(ui->tableWidgetComplete, SIGNAL(cellDoubleClicked(int,int)), this, SLOT(getLinkDetails(int,int)));
 
     connect(ui->pushButtonAddLink, SIGNAL(clicked()), this, SLOT(addLink()));
+
 }
 
 BdapPage::~BdapPage()
@@ -101,6 +105,15 @@ BdapPage::~BdapPage()
 void BdapPage::setModel(WalletModel* model)
 {
     this->model = model;
+}
+
+void BdapPage::setClientModel(ClientModel* _clientModel)
+{
+    this->clientModel = _clientModel;
+
+    if (_clientModel) {
+        connect(_clientModel, SIGNAL(numBlocksChanged(int, QDateTime, double, bool)), this, SLOT(updateBDAPLists()));
+    }
 }
 
 void BdapPage::evaluateTransactionButtons()
@@ -226,6 +239,27 @@ void BdapPage::getGroupDetails(int row, int column)
     dlg.setWindowTitle(QObject::tr("BDAP Group Detail"));
     dlg.exec();
 } //getGroupDetails
+
+void BdapPage::updateBDAPLists()
+{
+    if (dynodeSync.IsBlockchainSynced())  {
+        evaluateTransactionButtons();
+
+        bdapAccountTableModel->refreshUsers();
+        bdapAccountTableModel->refreshGroups();
+        bdapLinkTableModel->refreshComplete();
+        bdapLinkTableModel->refreshPendingAccept();
+        bdapLinkTableModel->refreshPendingRequest();
+    }
+} //updateBDAPLists
+
+
+
+
+
+
+
+
 
 //Users tab =========================================================================
 void BdapPage::listAllUsers()

--- a/src/qt/bdappage.cpp
+++ b/src/qt/bdappage.cpp
@@ -58,7 +58,6 @@ BdapPage::BdapPage(const PlatformStyle* platformStyle, QWidget* parent) : QWidge
 
     connect(ui->tableWidget_Users, SIGNAL(cellDoubleClicked(int,int)), this, SLOT(getUserDetails(int,int)));
 
-
     //Groups tab
     connect(ui->pushButton_AllGroups, SIGNAL(clicked()), this, SLOT(listAllGroups()));
     connect(ui->addGroup, SIGNAL(clicked()), this, SLOT(addGroup()));
@@ -69,13 +68,10 @@ BdapPage::BdapPage(const PlatformStyle* platformStyle, QWidget* parent) : QWidge
     connect(ui->lineEditGroupCommonNameSearch, SIGNAL(textChanged(const QString &)), this, SLOT(listAllGroups()));
     connect(ui->lineEditGroupFullPathSearch, SIGNAL(textChanged(const QString &)), this, SLOT(listAllGroups()));
 
-
     connect(ui->tableWidget_Groups, SIGNAL(cellDoubleClicked(int,int)), this, SLOT(getGroupDetails(int,int)));
 
     //Links tab
-    connect(ui->pushButtonRefreshComplete, SIGNAL(clicked()), this, SLOT(listLinksComplete()));
-    connect(ui->pushButtonRefreshPendingAccept, SIGNAL(clicked()), this, SLOT(listPendingAccept()));
-    connect(ui->pushButtonRefreshPendingRequest, SIGNAL(clicked()), this, SLOT(listPendingRequest()));
+    connect(ui->pushButtonRefreshAllLinks, SIGNAL(clicked()), this, SLOT(listLinksAll()));
 
     connect(ui->lineEditCompleteRequestorSearch, SIGNAL(textChanged(const QString &)), this, SLOT(listLinksComplete()));
     connect(ui->lineEditCompleteRecipientSearch, SIGNAL(textChanged(const QString &)), this, SLOT(listLinksComplete()));
@@ -86,7 +82,6 @@ BdapPage::BdapPage(const PlatformStyle* platformStyle, QWidget* parent) : QWidge
     connect(ui->lineEditPRRequestorSearch, SIGNAL(textChanged(const QString &)), this, SLOT(listPendingRequest()));
     connect(ui->lineEditPRRecipientSearch, SIGNAL(textChanged(const QString &)), this, SLOT(listPendingRequest()));
 
-
     connect(ui->pushButtonAccept, SIGNAL(clicked()), this, SLOT(acceptLink()));
 
     connect(ui->tableWidgetPendingAccept, SIGNAL(cellDoubleClicked(int,int)), this, SLOT(getLinkDetails(int,int)));
@@ -94,7 +89,6 @@ BdapPage::BdapPage(const PlatformStyle* platformStyle, QWidget* parent) : QWidge
     connect(ui->tableWidgetComplete, SIGNAL(cellDoubleClicked(int,int)), this, SLOT(getLinkDetails(int,int)));
 
     connect(ui->pushButtonAddLink, SIGNAL(clicked()), this, SLOT(addLink()));
-
 }
 
 BdapPage::~BdapPage()
@@ -136,6 +130,11 @@ void BdapPage::evaluateTransactionButtons()
 } //evaluateTransactionButtons
 
 //Links tab =========================================================================
+void BdapPage::listLinksAll()
+{
+    bdapLinkTableModel->refreshAll();
+} //listLinksAll
+
 void BdapPage::listLinksComplete()
 {
     bdapLinkTableModel->refreshComplete();
@@ -252,14 +251,6 @@ void BdapPage::updateBDAPLists()
         bdapLinkTableModel->refreshPendingRequest();
     }
 } //updateBDAPLists
-
-
-
-
-
-
-
-
 
 //Users tab =========================================================================
 void BdapPage::listAllUsers()

--- a/src/qt/bdappage.cpp
+++ b/src/qt/bdappage.cpp
@@ -2,22 +2,23 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "bdappage.h"
-#include "ui_bdappage.h"
-#include "bdapadduserdialog.h"
+#include "bdap/fees.h"
+#include "bdapaccounttablemodel.h"
 #include "bdapaddlinkdialog.h"
+#include "bdapadduserdialog.h"
+#include "bdapfeespopup.h"
+#include "bdaplinkdetaildialog.h"
+#include "bdaplinktablemodel.h"
+#include "bdappage.h"
 #include "bdapupdateaccountdialog.h"
 #include "bdapuserdetaildialog.h"
-#include "bdaplinkdetaildialog.h"
-#include "guiutil.h"
-#include "walletmodel.h"
-#include "bdapaccounttablemodel.h"
-#include "bdaplinktablemodel.h"
 #include "dynode-sync.h"
-
+#include "guiutil.h"
+#include "rpcclient.h"
 #include "rpcregister.h"
 #include "rpcserver.h"
-#include "rpcclient.h"
+#include "ui_bdappage.h"
+#include "walletmodel.h"
 
 #include <stdio.h>
 
@@ -297,6 +298,11 @@ void BdapPage::acceptLink()
     reply = QMessageBox::question(this, QObject::tr("Confirm Accept Link"), QObject::tr(displayedMessage.c_str()), QMessageBox::Yes|QMessageBox::No);
 
     if (reply == QMessageBox::Yes) {
+
+        if (!bdapFeesPopup(this,OP_BDAP_NEW,OP_BDAP_LINK_ACCEPT,BDAP::ObjectType::BDAP_LINK_ACCEPT)) {
+            return;
+        }
+
         executeLinkTransaction(LinkActions::LINK_ACCEPT, requestor, recipient);
     }
 

--- a/src/qt/bdappage.h
+++ b/src/qt/bdappage.h
@@ -5,15 +5,14 @@
 #ifndef BDAPPAGE_H
 #define BDAPPAGE_H
 
+#include "bdap/bdap.h"
 #include "platformstyle.h"
 #include "walletmodel.h"
-#include "bdap/bdap.h"
 
 #include <QPushButton>
 #include <QWidget>
 
 #include <memory>
-
 
 class BdapAccountTableModel;
 class BdapLinkTableModel;

--- a/src/qt/bdappage.h
+++ b/src/qt/bdappage.h
@@ -100,6 +100,7 @@ private Q_SLOTS:
     void updateGroup();
     void getGroupDetails(int row, int column);
 
+    void listLinksAll();
     void listLinksComplete();
     void listPendingAccept();
     void listPendingRequest();

--- a/src/qt/bdappage.h
+++ b/src/qt/bdappage.h
@@ -16,6 +16,7 @@
 
 class BdapAccountTableModel;
 class BdapLinkTableModel;
+class ClientModel;
 class QTableWidget;
 class QLabel;
 
@@ -44,6 +45,7 @@ public:
     explicit BdapPage(const PlatformStyle* platformStyle, QWidget* parent = 0);
     ~BdapPage();
 
+    void setClientModel(ClientModel* clientModel);
     void setModel(WalletModel* model);
     BdapAccountTableModel* getBdapAccountTableModel();
     BdapLinkTableModel* getBdapLinkTableModel();
@@ -76,6 +78,7 @@ public:
 
 private:
     Ui::BdapPage* ui;
+    ClientModel* clientModel;
     WalletModel* model;
     std::unique_ptr<WalletModel::UnlockContext> unlockContext;
     BdapAccountTableModel* bdapAccountTableModel;
@@ -103,6 +106,8 @@ private Q_SLOTS:
     void acceptLink();
     void addLink();
     void getLinkDetails(int row, int column);
+
+    void updateBDAPLists();
 
 };
 

--- a/src/qt/forms/bdapadduserdialog.ui
+++ b/src/qt/forms/bdapadduserdialog.ui
@@ -35,14 +35,14 @@
         <widget class="QLineEdit" name="lineEdit_commonName"/>
        </item>
        <item row="2" column="0">
-        <widget class="QLabel" name="labelRegistrationDays">
+        <widget class="QLabel" name="labelRegistrationMonths">
          <property name="text">
           <string>Registration months:</string>
          </property>
         </widget>
        </item>
        <item row="2" column="1">
-        <widget class="QLineEdit" name="lineEdit_registrationDays"/>
+        <widget class="QLineEdit" name="lineEdit_registrationMonths"/>
        </item>
        <item row="0" column="0">
         <widget class="QLabel" name="labelUserId">

--- a/src/qt/forms/bdappage.ui
+++ b/src/qt/forms/bdappage.ui
@@ -413,6 +413,12 @@ QTabBar { alignment: left; }
             <layout class="QHBoxLayout" name="horizontalLayout_14">
              <item>
               <widget class="QLabel" name="labelPA">
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>25</height>
+                </size>
+               </property>
                <property name="text">
                 <string>Pending Accept</string>
                </property>
@@ -437,19 +443,6 @@ QTabBar { alignment: left; }
                 </size>
                </property>
               </spacer>
-             </item>
-             <item>
-              <widget class="QPushButton" name="pushButtonRefreshPendingAccept">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Refresh</string>
-               </property>
-              </widget>
              </item>
             </layout>
            </item>
@@ -582,6 +575,12 @@ QTabBar { alignment: left; }
             <layout class="QHBoxLayout" name="horizontalLayout_15">
              <item>
               <widget class="QLabel" name="labelPR">
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>25</height>
+                </size>
+               </property>
                <property name="text">
                 <string>Pending Request</string>
                </property>
@@ -606,19 +605,6 @@ QTabBar { alignment: left; }
                 </size>
                </property>
               </spacer>
-             </item>
-             <item>
-              <widget class="QPushButton" name="pushButtonRefreshPendingRequest">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Refresh</string>
-               </property>
-              </widget>
              </item>
             </layout>
            </item>
@@ -740,7 +726,7 @@ QTabBar { alignment: left; }
               </spacer>
              </item>
              <item>
-              <widget class="QPushButton" name="pushButtonRefreshComplete">
+              <widget class="QPushButton" name="pushButtonRefreshAllLinks">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                  <horstretch>0</horstretch>
@@ -748,7 +734,7 @@ QTabBar { alignment: left; }
                 </sizepolicy>
                </property>
                <property name="text">
-                <string>Refresh</string>
+                <string>Refresh All</string>
                </property>
               </widget>
              </item>

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -154,6 +154,7 @@ void WalletView::setClientModel(ClientModel* _clientModel)
 
     overviewPage->setClientModel(_clientModel);
     sendCoinsPage->setClientModel(_clientModel);
+    bdapPage->setClientModel(_clientModel);
     QSettings settings;
     if (settings.value("fShowDynodesTab").toBool()) {
         dynodeListPage->setClientModel(_clientModel);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4545,8 +4545,7 @@ bool CWallet::SyncEdKeyPool()
             if (!walletdb.WriteEdPool(nIndex, CEdKeyPool(GenerateNewEdKey(0, true, retrievedKey), true)))
                 throw std::runtime_error("SyncEdKeyPool(): writing generated key failed");
             else {
-                setInternalEdKeyPool.insert(nIndex);    
-                LogPrintf("edkeypool added key %d, size=%u, internal=%d\n", nIndex, setInternalEdKeyPool.size() + setExternalEdKeyPool.size(), 1);
+                setInternalEdKeyPool.insert(nIndex);
             }
         }
     }
@@ -4569,8 +4568,7 @@ bool CWallet::SyncEdKeyPool()
             if (!walletdb.WriteEdPool(nIndex, CEdKeyPool(GenerateNewEdKey(0, false, retrievedKey2), false)))
                 throw std::runtime_error("SyncEdKeyPool(): writing generated key failed");
             else {
-                setExternalEdKeyPool.insert(nIndex);    
-                LogPrintf("edkeypool added key %d, size=%u, internal=%d\n", nIndex, setInternalEdKeyPool.size() + setExternalEdKeyPool.size(), 0);
+                setExternalEdKeyPool.insert(nIndex);
             }
         }
     }
@@ -4638,7 +4636,6 @@ bool CWallet::TopUpKeyPoolCombo(unsigned int kpSize)
             } else {
                 setExternalKeyPool.insert(nEnd);
             }
-            LogPrintf("keypool added key %d, size=%u, internal=%d\n", nEnd, setInternalKeyPool.size() + setExternalKeyPool.size(), fInternal);
 
             // TODO: implement keypools for all accounts?
             if (!walletdb.WriteEdPool(nEnd, CEdKeyPool(GenerateNewEdKey(0, fInternal, retrievedKey), fInternal)))
@@ -4649,7 +4646,6 @@ bool CWallet::TopUpKeyPoolCombo(unsigned int kpSize)
             } else {
                 setExternalEdKeyPool.insert(nEnd);
             }
-            LogPrintf("edkeypool added key %d, size=%u, internal=%d\n", nEnd, setInternalEdKeyPool.size() + setExternalEdKeyPool.size(), fInternal);
 
             double dProgress = 100.f * nEnd / (nTargetSize + 1);
             std::string strMsg = strprintf(_("Loading wallet... (%3.2f %%)"), dProgress);


### PR DESCRIPTION
- Remove the logging of key creation
- Add fee warning before executing BDAP add/modify transactions
- Update BDAP lists based on received blocks signal instead of a timer
- Consolidate the 3 refresh BDAP link buttons into 1
- Check if insufficient funds before fee warnings and code optimizations
- Add validation checks for registration months (GUI and RPC)
- Add search to rpc getusers and getgroups
