### PR TITLE
Updates to BDAP DHT for v2.4.22

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 [submodule "src/libtorrent"]
 	path = src/libtorrent
 	url = https://github.com/duality-solutions/libbdaptorrent.git
+	branch = incompatible

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -131,6 +131,7 @@ DYNAMIC_CORE_H = \
   dht/datarecord.h \
   dht/dataset.h \
   dht/ed25519.h \
+  dht/limits.h \
   dht/mutable.h \
   dht/mutabledb.h \
   dht/session.h \
@@ -287,6 +288,7 @@ libdynamic_server_a_SOURCES = \
   dht/dataheader.cpp \
   dht/datarecord.cpp \
   dht/dataset.cpp \
+  dht/limits.cpp \
   dht/mutable.cpp \
   dht/mutabledb.cpp \
   dht/rpcdht.cpp \

--- a/src/bdap/domainentrydb.cpp
+++ b/src/bdap/domainentrydb.cpp
@@ -45,6 +45,12 @@ bool GetDomainEntryPubKey(const std::vector<unsigned char>& vchPubKey, CDomainEn
     return !entry.IsNull();
 }
 
+bool AccountPubKeyExists(const std::vector<unsigned char>& vchPubKey)
+{
+    CDomainEntry entry;
+    return GetDomainEntryPubKey(vchPubKey, entry);
+}
+
 bool DomainEntryExists(const std::vector<unsigned char>& vchObjectPath)
 {
     if (!pDomainEntryDB)

--- a/src/bdap/domainentrydb.h
+++ b/src/bdap/domainentrydb.h
@@ -41,6 +41,7 @@ public:
 
 bool GetDomainEntry(const std::vector<unsigned char>& vchObjectPath, CDomainEntry& entry);
 bool GetDomainEntryPubKey(const std::vector<unsigned char>& vchPubKey, CDomainEntry& entry);
+bool AccountPubKeyExists(const std::vector<unsigned char>& vchPubKey);
 bool DomainEntryExists(const std::vector<unsigned char>& vchObjectPath);
 bool DeleteDomainEntry(const CDomainEntry& entry);
 bool UndoAddDomainEntry(const CDomainEntry& entry);

--- a/src/bdap/fees.cpp
+++ b/src/bdap/fees.cpp
@@ -9,28 +9,30 @@
 #include "util.h" // for LogPrintf
 
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <limits>
+#include <map>
 
 // Default BDAP Monthly Fees
-std::map<int32_t, CAmount> mapDefaultMonthlyFees = {
-    {BDAP_MONTHY_USER_FEE, 50 * BDAP_CREDIT},
-    {BDAP_MONTHY_GROUP_FEE, 200 * BDAP_CREDIT},
-    {BDAP_MONTHY_CERTIFICATE_FEE, 100 * BDAP_CREDIT},
-    {BDAP_MONTHY_SIDECHAIN_FEE, 1000 * BDAP_CREDIT},
+std::map<int32_t, CFeeItem> mapDefaultMonthlyFees = {
+    {BDAP_MONTHY_USER_FEE, CFeeItem(BDAP_MONTHY_USER_FEE, 50 * BDAP_CREDIT, 0, std::numeric_limits<unsigned int>::max())},
+    {BDAP_MONTHY_GROUP_FEE, CFeeItem(BDAP_MONTHY_GROUP_FEE, 200 * BDAP_CREDIT, 0, std::numeric_limits<unsigned int>::max())},
+    {BDAP_MONTHY_CERTIFICATE_FEE, CFeeItem(BDAP_MONTHY_CERTIFICATE_FEE, 100 * BDAP_CREDIT, 0, std::numeric_limits<unsigned int>::max())},
+    {BDAP_MONTHY_SIDECHAIN_FEE, CFeeItem(BDAP_MONTHY_SIDECHAIN_FEE, 1000 * BDAP_CREDIT, 0, std::numeric_limits<unsigned int>::max())},
 };
 
 // Default BDAP One Time Fees
-std::map<int32_t, CAmount> mapOneTimeFees = {
-    {BDAP_ONE_TIME_REQUEST_LINK_FEE, 99 * BDAP_CREDIT},
-    {BDAP_ONE_TIME_ACCEPT_LINK_FEE, 99 * BDAP_CREDIT},
-    {BDAP_ONE_TIME_AUDIT_RECORD_FEE, 99 * BDAP_CREDIT},
+std::multimap<int32_t, CFeeItem> mapOneTimeFees = {
+    {BDAP_ONE_TIME_REQUEST_LINK_FEE, CFeeItem(BDAP_ONE_TIME_REQUEST_LINK_FEE, 99 * BDAP_CREDIT, 0, std::numeric_limits<unsigned int>::max())},
+    {BDAP_ONE_TIME_ACCEPT_LINK_FEE, CFeeItem(BDAP_ONE_TIME_ACCEPT_LINK_FEE, 99 * BDAP_CREDIT, 0, std::numeric_limits<unsigned int>::max())},
+    {BDAP_ONE_TIME_AUDIT_RECORD_FEE, CFeeItem(BDAP_ONE_TIME_AUDIT_RECORD_FEE, 99 * BDAP_CREDIT, 0, std::numeric_limits<unsigned int>::max())},
 };
 
 // Default BDAP Non-Refundable Security Deposit Fees
-std::map<int32_t, CAmount> mapNoRefundDeposits = {
-    {BDAP_NON_REFUNDABLE_USER_DEPOSIT, 1000 * BDAP_CREDIT},
-    {BDAP_NON_REFUNDABLE_GROUP_DEPOSIT, 10000 * BDAP_CREDIT},
-    {BDAP_NON_REFUNDABLE_CERTIFICATE_DEPOSIT, 5000 * BDAP_CREDIT},
-    {BDAP_NON_REFUNDABLE_SIDECHAIN_DEPOSIT, 25000 * BDAP_CREDIT},
+std::map<int32_t, CFeeItem> mapNoRefundDeposits = {
+    {BDAP_NON_REFUNDABLE_USER_DEPOSIT, CFeeItem(BDAP_NON_REFUNDABLE_USER_DEPOSIT, 1000 * BDAP_CREDIT, 0, std::numeric_limits<unsigned int>::max())},
+    {BDAP_NON_REFUNDABLE_GROUP_DEPOSIT, CFeeItem(BDAP_NON_REFUNDABLE_GROUP_DEPOSIT, 10000 * BDAP_CREDIT, 0, std::numeric_limits<unsigned int>::max())},
+    {BDAP_NON_REFUNDABLE_CERTIFICATE_DEPOSIT, CFeeItem(BDAP_NON_REFUNDABLE_CERTIFICATE_DEPOSIT, 5000 * BDAP_CREDIT, 0, std::numeric_limits<unsigned int>::max())},
+    {BDAP_NON_REFUNDABLE_SIDECHAIN_DEPOSIT, CFeeItem(BDAP_NON_REFUNDABLE_SIDECHAIN_DEPOSIT, 25000 * BDAP_CREDIT, 0, std::numeric_limits<unsigned int>::max())},
 };
 
 bool GetBDAPFees(const opcodetype& opCodeAction, const opcodetype& opCodeObject, const BDAP::ObjectType objType, const uint16_t nMonths, CAmount& monthlyFee, CAmount& oneTimeFee, CAmount& depositFee)
@@ -38,67 +40,118 @@ bool GetBDAPFees(const opcodetype& opCodeAction, const opcodetype& opCodeObject,
     std::string strObjectType = BDAP::GetObjectTypeString((unsigned int)objType);
     LogPrint("bdap", "%s -- strObjectType = %s, OpAction %d, OpObject %d\n", __func__, strObjectType, opCodeAction, opCodeObject);
     if (opCodeAction == OP_BDAP_NEW && opCodeObject == OP_BDAP_ACCOUNT_ENTRY && objType == BDAP::ObjectType::BDAP_USER) {
-        // new BDAP user account
+        // Fees for a new BDAP user account
         oneTimeFee = 0;
-        monthlyFee = mapDefaultMonthlyFees[BDAP_MONTHY_USER_FEE] * nMonths;
-        depositFee = mapNoRefundDeposits[BDAP_NON_REFUNDABLE_USER_DEPOSIT];
+        CFeeItem feeMonthly;
+        std::multimap<int32_t, CFeeItem>::iterator iMonthly = mapDefaultMonthlyFees.find(BDAP_MONTHY_USER_FEE);
+        if (iMonthly != mapDefaultMonthlyFees.end()) {
+            feeMonthly = iMonthly->second;
+            monthlyFee = (nMonths * feeMonthly.Fee);
+        }
+        CFeeItem feeDeposit;
+        std::multimap<int32_t, CFeeItem>::iterator iDeposit = mapNoRefundDeposits.find(BDAP_NON_REFUNDABLE_USER_DEPOSIT);
+        if (iDeposit != mapNoRefundDeposits.end()) {
+            feeDeposit = iDeposit->second;
+            depositFee = feeDeposit.Fee;
+        }
 
     } else if (opCodeAction == OP_BDAP_NEW && opCodeObject == OP_BDAP_ACCOUNT_ENTRY && objType == BDAP::ObjectType::BDAP_GROUP) {
-        // new BDAP group account
+        // Fees for a new BDAP group account
         oneTimeFee = 0;
-        monthlyFee = mapDefaultMonthlyFees[BDAP_MONTHY_GROUP_FEE] * nMonths;
-        depositFee = mapNoRefundDeposits[BDAP_NON_REFUNDABLE_GROUP_DEPOSIT];
+        CFeeItem feeMonthly;
+        std::multimap<int32_t, CFeeItem>::iterator iMonthly = mapDefaultMonthlyFees.find(BDAP_MONTHY_GROUP_FEE);
+        if (iMonthly != mapDefaultMonthlyFees.end()) {
+            feeMonthly = iMonthly->second;
+            monthlyFee = (nMonths * feeMonthly.Fee);
+        }
+        CFeeItem feeDeposit;
+        std::multimap<int32_t, CFeeItem>::iterator iDeposit = mapNoRefundDeposits.find(BDAP_NON_REFUNDABLE_GROUP_DEPOSIT);
+        if (iDeposit != mapNoRefundDeposits.end()) {
+            feeDeposit = iDeposit->second;
+            depositFee = feeDeposit.Fee;
+        }
 
     } else if (opCodeAction == OP_BDAP_NEW && opCodeObject == OP_BDAP_CERTIFICATE && objType == BDAP::ObjectType::BDAP_CERTIFICATE) {
-        // new BDAP certificate
+        // Fees for a new BDAP certificate
         oneTimeFee = 0;
-        monthlyFee = mapDefaultMonthlyFees[BDAP_MONTHY_CERTIFICATE_FEE] * nMonths;
-        depositFee = mapNoRefundDeposits[BDAP_NON_REFUNDABLE_CERTIFICATE_DEPOSIT];
+        CFeeItem feeMonthly;
+        std::multimap<int32_t, CFeeItem>::iterator iMonthly = mapDefaultMonthlyFees.find(BDAP_MONTHY_CERTIFICATE_FEE);
+        if (iMonthly != mapDefaultMonthlyFees.end()) {
+            feeMonthly = iMonthly->second;
+            monthlyFee = (nMonths * feeMonthly.Fee);
+        }
+        CFeeItem feeDeposit;
+        std::multimap<int32_t, CFeeItem>::iterator iDeposit = mapNoRefundDeposits.find(BDAP_NON_REFUNDABLE_CERTIFICATE_DEPOSIT);
+        if (iDeposit != mapNoRefundDeposits.end()) {
+            feeDeposit = iDeposit->second;
+            depositFee = feeDeposit.Fee;
+        }
 
     } else if (opCodeAction == OP_BDAP_NEW && opCodeObject == OP_BDAP_SIDECHAIN && objType == BDAP::ObjectType::BDAP_SIDECHAIN) {
-        // new BDAP sidechain entry
+        // Fees for a new BDAP sidechain entry
         oneTimeFee = 0;
-        monthlyFee = mapDefaultMonthlyFees[BDAP_MONTHY_SIDECHAIN_FEE] * nMonths;
-        depositFee = mapNoRefundDeposits[BDAP_NON_REFUNDABLE_SIDECHAIN_DEPOSIT];
+        CFeeItem feeMonthly;
+        std::multimap<int32_t, CFeeItem>::iterator iMonthly = mapDefaultMonthlyFees.find(BDAP_MONTHY_SIDECHAIN_FEE);
+        if (iMonthly != mapDefaultMonthlyFees.end()) {
+            feeMonthly = iMonthly->second;
+            monthlyFee = (nMonths * feeMonthly.Fee);
+        }
+        CFeeItem feeDeposit;
+        std::multimap<int32_t, CFeeItem>::iterator iDeposit = mapNoRefundDeposits.find(BDAP_NON_REFUNDABLE_SIDECHAIN_DEPOSIT);
+        if (iDeposit != mapNoRefundDeposits.end()) {
+            feeDeposit = iDeposit->second;
+            depositFee = feeDeposit.Fee;
+        }
 
     } else if (opCodeAction == OP_BDAP_NEW && opCodeObject == OP_BDAP_LINK_REQUEST && objType == BDAP::ObjectType::BDAP_LINK_REQUEST) {
-        // new BDAP link request
-        oneTimeFee = mapOneTimeFees[BDAP_ONE_TIME_REQUEST_LINK_FEE];
+        // Fees for a new BDAP link request
+        CFeeItem feeOneTime;
+        std::multimap<int32_t, CFeeItem>::iterator iOneTime = mapOneTimeFees.find(BDAP_ONE_TIME_REQUEST_LINK_FEE);
+        if (iOneTime != mapOneTimeFees.end()) {
+            feeOneTime = iOneTime->second;
+            oneTimeFee = feeOneTime.Fee;
+        }
         monthlyFee = 0;
         depositFee = BDAP_CREDIT;
 
     } else if (opCodeAction == OP_BDAP_NEW && opCodeObject == OP_BDAP_LINK_ACCEPT && objType == BDAP::ObjectType::BDAP_LINK_ACCEPT) {
-        // new BDAP link accept
-        oneTimeFee = mapOneTimeFees[BDAP_ONE_TIME_ACCEPT_LINK_FEE];
+        // Fees for a new BDAP link accept
+        CFeeItem feeOneTime;
+        std::multimap<int32_t, CFeeItem>::iterator iOneTime = mapOneTimeFees.find(BDAP_ONE_TIME_ACCEPT_LINK_FEE);
+        if (iOneTime != mapOneTimeFees.end()) {
+            feeOneTime = iOneTime->second;
+            oneTimeFee = feeOneTime.Fee;
+        }
         monthlyFee = 0;
         depositFee = BDAP_CREDIT;
 
     } else if (opCodeAction == OP_BDAP_NEW && opCodeObject == OP_BDAP_AUDIT && objType == BDAP::ObjectType::BDAP_AUDIT) {
-        // new BDAP audit record
-        oneTimeFee = mapOneTimeFees[BDAP_ONE_TIME_AUDIT_RECORD_FEE];
+        // Fees for a new BDAP audit record
+        CFeeItem feeOneTime;
+        std::multimap<int32_t, CFeeItem>::iterator iOneTime = mapOneTimeFees.find(BDAP_ONE_TIME_AUDIT_RECORD_FEE);
+        if (iOneTime != mapOneTimeFees.end()) {
+            feeOneTime = iOneTime->second;
+            oneTimeFee = feeOneTime.Fee;
+        }
         monthlyFee = 0;
         depositFee = BDAP_CREDIT;
 
     } else if (opCodeAction == OP_BDAP_MODIFY && opCodeObject == OP_BDAP_ACCOUNT_ENTRY && objType == BDAP::ObjectType::BDAP_USER) {
-        // update BDAP user account entry
+        // Fees for an update BDAP user account entry
         oneTimeFee = 0;
         monthlyFee = 0;
         depositFee = BDAP_CREDIT;
 
     } else if (opCodeAction == OP_BDAP_MODIFY && opCodeObject == OP_BDAP_ACCOUNT_ENTRY && objType == BDAP::ObjectType::BDAP_GROUP) {
-        // update BDAP group account entry
+        // Fees for an update BDAP group account entry
         oneTimeFee = 0;
         monthlyFee = 0;
         depositFee = BDAP_CREDIT;
-    } else if (objType == BDAP::ObjectType::BDAP_DEFAULT_TYPE) {
-        // ********** TODO (BDAP): Remove this
-        oneTimeFee = 0;
+    } else {
+        oneTimeFee = BDAP_CREDIT;
         monthlyFee = 0;
         depositFee = BDAP_CREDIT;
-    }
-    else {
         LogPrintf("%s -- BDAP operation code pair (%d and %d) for %s not found or unsupported.\n", __func__, opCodeAction, opCodeObject, strObjectType);
-        return false;
     }
 
     return true;

--- a/src/bdap/fees.h
+++ b/src/bdap/fees.h
@@ -36,6 +36,18 @@ static const int32_t BDAP_NON_REFUNDABLE_GROUP_DEPOSIT          = 7002;
 static const int32_t BDAP_NON_REFUNDABLE_CERTIFICATE_DEPOSIT    = 7003;
 static const int32_t BDAP_NON_REFUNDABLE_SIDECHAIN_DEPOSIT      = 7004;
 
+class CFeeItem {
+public:
+    static const int CURRENT_VERSION=1;
+    int nVersion;
+    int32_t nType;
+    CAmount Fee;
+    unsigned int nStartHeight;
+    unsigned int nEndHeight;
+    CFeeItem() : nVersion(CURRENT_VERSION), nType(0), Fee(0), nStartHeight(0), nEndHeight(0) {}
+    CFeeItem(const int32_t& type, const CAmount& fee, const unsigned int& start, const unsigned int& end) : nVersion(CURRENT_VERSION), nType(type), Fee(fee), nStartHeight(start), nEndHeight(end) {}
+};
+
 bool GetBDAPFees(const opcodetype& opCodeAction, const opcodetype& opCodeObject, const BDAP::ObjectType objType, const uint16_t nMonths, CAmount& monthlyFee, CAmount& oneTimeFee, CAmount& depositFee);
 int64_t AddMonthsToCurrentEpoch(const short nMonths);
 int64_t AddMonthsToBlockTime(const uint32_t& nBlockTime, const short nMonths);

--- a/src/bdap/linkingdb.cpp
+++ b/src/bdap/linkingdb.cpp
@@ -295,3 +295,11 @@ bool CheckPreviousLinkInputs(const std::string& strOpType, const CScript& script
     }
     return true;
 }
+
+bool LinkPubKeyExists(const std::vector<unsigned char>& vchPubKey)
+{
+    if (!CheckLinkDB())
+        return false;
+
+    return pLinkDB->LinkExists(vchPubKey);
+}

--- a/src/bdap/linkingdb.cpp
+++ b/src/bdap/linkingdb.cpp
@@ -13,25 +13,21 @@
 
 #include <boost/thread.hpp>
 
-CLinkRequestDB *pLinkRequestDB = NULL;
-CLinkAcceptDB *pLinkAcceptDB = NULL;
+CLinkDB *pLinkDB = NULL;
 
 bool UndoLinkData(const std::vector<unsigned char>& vchPubKey, const std::vector<unsigned char>& vchSharedPubKey)
 {
-    if (!pLinkRequestDB || !pLinkAcceptDB)
+    if (!pLinkDB)
         return false;
 
-    bool fEraseLinkRequestPubkey = pLinkRequestDB->EraseLinkRequestIndex(vchPubKey, vchSharedPubKey);
-    bool fEraseLinkAcceptPubkey = pLinkAcceptDB->EraseLinkAcceptIndex(vchPubKey, vchSharedPubKey);
-
-    return (fEraseLinkRequestPubkey && fEraseLinkAcceptPubkey);
+    return pLinkDB->EraseLinkIndex(vchPubKey, vchSharedPubKey);
 }
 
-bool CLinkRequestDB::AddLinkRequestIndex(const vchCharString& vvchOpParameters, const uint256& txid)
+bool CLinkDB::AddLinkIndex(const vchCharString& vvchOpParameters, const uint256& txid)
 { 
     bool writeState = false;
     {
-        LOCK(cs_link_request);
+        LOCK(cs_link);
         writeState = Write(make_pair(std::string("pubkey"), stringFromVch(vvchOpParameters[0])), txid);
         if (writeState && vvchOpParameters.size() > 1)
             writeState = Write(make_pair(std::string("pubkey"), stringFromVch(vvchOpParameters[1])), txid);
@@ -40,21 +36,21 @@ bool CLinkRequestDB::AddLinkRequestIndex(const vchCharString& vvchOpParameters, 
     return writeState;
 }
 
-bool CLinkRequestDB::ReadLinkRequestIndex(const std::vector<unsigned char>& vchPubKey, uint256& txid)
+bool CLinkDB::ReadLinkIndex(const std::vector<unsigned char>& vchPubKey, uint256& txid)
 {
-    LOCK(cs_link_request);
+    LOCK(cs_link);
     return CDBWrapper::Read(make_pair(std::string("pubkey"), vchPubKey), txid);
 }
 
-bool CLinkRequestDB::EraseLinkRequestIndex(const std::vector<unsigned char>& vchPubKey, const std::vector<unsigned char>& vchSharedPubKey)
+bool CLinkDB::EraseLinkIndex(const std::vector<unsigned char>& vchPubKey, const std::vector<unsigned char>& vchSharedPubKey)
 {
-    if (!LinkRequestExists(vchPubKey)) 
+    if (!LinkExists(vchPubKey)) 
         return false;
-    if (!LinkRequestExists(vchSharedPubKey)) 
+    if (!LinkExists(vchSharedPubKey)) 
         return false;
 
     bool result = false;
-    LOCK(cs_link_request);
+    LOCK(cs_link);
     result = CDBWrapper::Erase(make_pair(std::string("pubkey"), vchPubKey));
     if (!result)
         return false;
@@ -62,117 +58,37 @@ bool CLinkRequestDB::EraseLinkRequestIndex(const std::vector<unsigned char>& vch
     return CDBWrapper::Erase(make_pair(std::string("pubkey"), vchSharedPubKey));
 }
 
-bool CLinkRequestDB::LinkRequestExists(const std::vector<unsigned char>& vchPubKey)
+bool CLinkDB::LinkExists(const std::vector<unsigned char>& vchPubKey)
 {
-    LOCK(cs_link_request);
+    LOCK(cs_link);
     return CDBWrapper::Exists(make_pair(std::string("pubkey"), vchPubKey));
 }
 
-// Link Accept DB
-bool CLinkAcceptDB::AddLinkAcceptIndex(const vchCharString& vvchOpParameters, const uint256& txid)
-{ 
-    bool writeState = false;
-    {
-        LOCK(cs_link_accept);
-        writeState = Write(make_pair(std::string("pubkey"), stringFromVch(vvchOpParameters[0])), txid);
-        if (writeState && vvchOpParameters.size() > 1)
-            writeState = Write(make_pair(std::string("pubkey"), stringFromVch(vvchOpParameters[1])), txid);
-    }
-
-    return writeState;
-}
-
-bool CLinkAcceptDB::ReadLinkAcceptIndex(const std::vector<unsigned char>& vchPubKey, uint256& txid)
-{
-    LOCK(cs_link_accept);
-    return CDBWrapper::Read(make_pair(std::string("pubkey"), vchPubKey), txid);
-}
-
-bool CLinkAcceptDB::EraseLinkAcceptIndex(const std::vector<unsigned char>& vchPubKey, const std::vector<unsigned char>& vchSharedPubKey)
-{
-    if (!LinkAcceptExists(vchPubKey)) 
-        return false;
-    if (!LinkAcceptExists(vchSharedPubKey)) 
-        return false;
-
-    bool result = false;
-    LOCK(cs_link_accept);
-    result = CDBWrapper::Erase(make_pair(std::string("pubkey"), vchPubKey));
-    if (!result)
-        return false;
-
-    return CDBWrapper::Erase(make_pair(std::string("pubkey"), vchSharedPubKey));
-}
-
-bool CLinkAcceptDB::LinkAcceptExists(const std::vector<unsigned char>& vchPubKey)
-{
-    LOCK(cs_link_accept);
-    return CDBWrapper::Exists(make_pair(std::string("pubkey"), vchPubKey));
-}
-
-bool GetLinkRequestIndex(const std::vector<unsigned char>& vchPubKey, uint256& txid)
+bool GetLinkIndex(const std::vector<unsigned char>& vchPubKey, uint256& txid)
 {
     txid.SetNull();
-    if (!pLinkRequestDB || !pLinkRequestDB->ReadLinkRequestIndex(vchPubKey, txid)) {
+    if (!pLinkDB || !pLinkDB->ReadLinkIndex(vchPubKey, txid)) {
         return false;
     }
     return !txid.IsNull();
 }
 
-bool GetLinkAcceptIndex(const std::vector<unsigned char>& vchPubKey, uint256& txid)
+bool CheckLinkDB()
 {
-    txid.SetNull();
-    if (!pLinkAcceptDB || !pLinkAcceptDB->ReadLinkAcceptIndex(vchPubKey, txid)) {
-        return false;
-    }
-    
-    return !txid.IsNull();
-}
-
-bool CheckLinkRequestDB()
-{
-    if (!pLinkRequestDB)
+    if (!pLinkDB)
         return false;
 
     return true;
 }
 
-bool CheckLinkAcceptDB()
-{
-    if (!pLinkAcceptDB)
-        return false;
-
-    return true;
-}
-
-bool CheckLinkDBs()
-{
-    return CheckLinkAcceptDB() && CheckLinkRequestDB();
-}
-
-bool FlushLinkRequestDB() 
+bool FlushLinkDB() 
 {
     {
-        LOCK(cs_link_request);
-        if (pLinkRequestDB != NULL)
+        LOCK(cs_link);
+        if (pLinkDB != NULL)
         {
-            if (!pLinkRequestDB->Flush()) {
-                LogPrintf("%s -- Failed to flush link request leveldb!\n", __func__);
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
-bool FlushLinkAcceptDB() 
-{
-    {
-        LOCK(cs_link_accept);
-        if (pLinkAcceptDB != NULL)
-        {
-            if (!pLinkAcceptDB->Flush()) {
-                LogPrintf("%s -- Failed to flush link accept leveldb!\n", __func__);
+            if (!pLinkDB->Flush()) {
+                LogPrintf("%s -- Failed to flush link leveldb!\n", __func__);
                 return false;
             }
         }
@@ -209,78 +125,38 @@ static bool CommonLinkParameterCheck(const vchCharString& vvchOpParameters, std:
     return true;
 }
 
-static bool CheckNewLinkRequestTx(const CScript& scriptData, const vchCharString& vvchOpParameters, const uint256& txid, std::string& errorMessage, bool fJustCheck)
+static bool CheckNewLinkTx(const CScript& scriptData, const vchCharString& vvchOpParameters, const uint256& txid, std::string& errorMessage, bool fJustCheck)
 {
     if (!CommonLinkParameterCheck(vvchOpParameters, errorMessage))
         return error(errorMessage.c_str());
 
     if (!scriptData.IsUnspendable()) {
-        errorMessage = "CheckNewLinkRequestTx failed! Data script should be unspendable.";
+        errorMessage = "CheckNewLinkTx failed! Data script should be unspendable.";
         return error(errorMessage.c_str());
     }
     CTxOut txout(0, scriptData);
     size_t nSize = GetSerializeSize(txout, SER_DISK,0)+148u;
     LogPrint("bdap", "%s -- scriptData.size() = %u, Serialize Size = %u \n", __func__, scriptData.size(), nSize);
     if (nSize > MAX_BDAP_LINK_DATA_SIZE) {
-        errorMessage = "CheckNewLinkRequestTx failed! Data script is too large.";
+        errorMessage = "CheckNewLinkTx failed! Data script is too large.";
         return error(errorMessage.c_str());
     }
     if (fJustCheck)
         return true;
 
-    if (!pLinkRequestDB)
+    if (!pLinkDB)
     {
-        errorMessage = "CheckNewLinkRequestTx failed! Can not open LevelDB BDAP link request database.";
+        errorMessage = "CheckNewLinkTx failed! Can not open LevelDB BDAP link database.";
         return error(errorMessage.c_str());
     }
-    if (!pLinkRequestDB->AddLinkRequestIndex(vvchOpParameters, txid))
+    if (!pLinkDB->AddLinkIndex(vvchOpParameters, txid))
     {
-        errorMessage = "CheckNewLinkRequestTx failed! Error adding link request index to LevelDB.";
+        errorMessage = "CheckNewLinkTx failed! Error adding link index to LevelDB.";
         return error(errorMessage.c_str());
     }
-    if (!FlushLinkRequestDB())
+    if (!FlushLinkDB())
     {
-        errorMessage = "CheckNewLinkRequestTx failed! Error flushing LevelDB.";
-        return error(errorMessage.c_str());
-    }
-    return true;
-}
-
-static bool CheckNewLinkAcceptTx(const CScript& scriptData, const vchCharString& vvchOpParameters, const uint256& txid, std::string& errorMessage, bool fJustCheck)
-{
-    if (!CommonLinkParameterCheck(vvchOpParameters, errorMessage))
-        return error(errorMessage.c_str());
-
-    if (!scriptData.IsUnspendable()) {
-        errorMessage = "CheckNewLinkAcceptTx failed! Data script should be unspendable.";
-        return error(errorMessage.c_str());
-    }
-    
-    CTxOut txout(0, scriptData);
-    size_t nSize = GetSerializeSize(txout, SER_DISK,0)+148u;
-    LogPrint("bdap", "%s -- scriptData.size() = %u, nSize = %u \n", __func__, scriptData.size(), nSize);
-    if (nSize > 1000) {
-        errorMessage = "CheckNewLinkAcceptTx failed! Data script is too large.";
-        return error(errorMessage.c_str());
-    }
-
-    if (fJustCheck)
-        return true;
-
-    if (!pLinkAcceptDB)
-    {
-        errorMessage = "CheckNewLinkAcceptTx failed! Can not open LevelDB BDAP link accept database.";
-        return error(errorMessage.c_str());
-    }
-
-    if (!pLinkAcceptDB->AddLinkAcceptIndex(vvchOpParameters, txid))
-    {
-        errorMessage = "CheckNewLinkAcceptTx failed! Error adding link accept index to LevelDB.";
-        return error(errorMessage.c_str());
-    }
-    if (!FlushLinkAcceptDB()) 
-    {
-        errorMessage = "CheckNewLinkAcceptTx failed! Error flushing LevelDB.";
+        errorMessage = "CheckNewLinkTx failed! Error flushing link LevelDB.";
         return error(errorMessage.c_str());
     }
     return true;
@@ -331,7 +207,7 @@ bool CheckLinkTx(const CTransactionRef& tx, const int& op1, const int& op2, cons
             LogPrint("bdap", "%s -- *** Valid BDAP fee amount for a new BDAP link request. Total paid %d, should be %d\n", __func__, 
                                 (dataAmount + opAmount), (monthlyFee + oneTimeFee + depositFee));
         }
-        return CheckNewLinkRequestTx(scriptData, vvchArgs, tx->GetHash(), errorMessage, fJustCheck);
+        return CheckNewLinkTx(scriptData, vvchArgs, tx->GetHash(), errorMessage, fJustCheck);
     }
     else if (strOperationType == "bdap_new_link_accept") {
         uint16_t nMonths = 0;
@@ -354,7 +230,7 @@ bool CheckLinkTx(const CTransactionRef& tx, const int& op1, const int& op2, cons
             LogPrint("bdap", "%s -- *** Valid BDAP fee amount for a new BDAP link accept. Total paid %d, should be %d\n", __func__, 
                                 (dataAmount + opAmount), (monthlyFee + oneTimeFee + depositFee));
         }
-        return CheckNewLinkAcceptTx(scriptData, vvchArgs, tx->GetHash(), errorMessage, fJustCheck);
+        return CheckNewLinkTx(scriptData, vvchArgs, tx->GetHash(), errorMessage, fJustCheck);
     }
 
     return false;
@@ -374,13 +250,13 @@ bool CheckPreviousLinkInputs(const std::string& strOpType, const CScript& script
         std::vector<unsigned char> vchPubKey = vvchOpParameters[0];
         uint256 prevTxId;
         if (strOpType == "bdap_delete_link_request") {
-            if (!GetLinkRequestIndex(vchPubKey, prevTxId)) {
+            if (!GetLinkIndex(vchPubKey, prevTxId)) {
                 errorMessage = "CheckPreviousLinkInputs: - " + _("Cannot get previous link request txid; this delete operation failed!");
                 return error(errorMessage.c_str());
             }
         }
         else if (strOpType == "bdap_delete_link_accept") {
-            if (!GetLinkAcceptIndex(vchPubKey, prevTxId)) {
+            if (!GetLinkIndex(vchPubKey, prevTxId)) {
                 errorMessage = "CheckPreviousLinkInputs: - " + _("Cannot get previous link accept txid; this delete operation failed!");
                 return error(errorMessage.c_str());
             }
@@ -411,10 +287,10 @@ bool CheckPreviousLinkInputs(const std::string& strOpType, const CScript& script
             vchSharedPubKey = vvchOpParameters[1];
 
         if (strOpType == "bdap_delete_link_request") {
-            pLinkRequestDB->EraseLinkRequestIndex(vchPubKey, vchSharedPubKey);
+            pLinkDB->EraseLinkIndex(vchPubKey, vchSharedPubKey);
         }
         else if (strOpType == "bdap_delete_link_accept") {
-            pLinkAcceptDB->EraseLinkAcceptIndex(vchPubKey, vchSharedPubKey);
+            pLinkDB->EraseLinkIndex(vchPubKey, vchSharedPubKey);
         }
     }
     return true;

--- a/src/bdap/linkingdb.h
+++ b/src/bdap/linkingdb.h
@@ -11,47 +11,29 @@
 
 class uint256;
 
-static CCriticalSection cs_link_request;
-static CCriticalSection cs_link_accept;
+static CCriticalSection cs_link;
 
-class CLinkRequestDB : public CDBWrapper {
+class CLinkDB : public CDBWrapper {
 public:
-    CLinkRequestDB(size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate) : CDBWrapper(GetDataDir() / "blocks" / "linkrequest", nCacheSize, fMemory, fWipe, obfuscate) {
+    CLinkDB(size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate) : CDBWrapper(GetDataDir() / "blocks" / "links", nCacheSize, fMemory, fWipe, obfuscate) {
     }
 
-    bool AddLinkRequestIndex(const vchCharString& vvchOpParameters, const uint256& txid);
-    bool ReadLinkRequestIndex(const std::vector<unsigned char>& vchPubKey, uint256& txid);
-    bool EraseLinkRequestIndex(const std::vector<unsigned char>& vchPubKey, const std::vector<unsigned char>& vchSharedPubKey);
-    bool LinkRequestExists(const std::vector<unsigned char>& vchPubKey);
-    //bool CleanupIndexLinkRequestDB(int& nRemoved);
-};
-
-class CLinkAcceptDB : public CDBWrapper {
-public:
-    CLinkAcceptDB(size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate) : CDBWrapper(GetDataDir() / "blocks" / "linkaccept", nCacheSize, fMemory, fWipe, obfuscate) {
-    }
-
-    bool AddLinkAcceptIndex(const vchCharString& vvchOpParameters, const uint256& txid);
-    bool ReadLinkAcceptIndex(const std::vector<unsigned char>& vchPubKey, uint256& txid);
-    bool EraseLinkAcceptIndex(const std::vector<unsigned char>& vchPubKey, const std::vector<unsigned char>& vchSharedPubKey);
-    bool LinkAcceptExists(const std::vector<unsigned char>& vchPubKey);
-    //bool CleanupIndexLinkAcceptDB(int& nRemoved);
+    bool AddLinkIndex(const vchCharString& vvchOpParameters, const uint256& txid);
+    bool ReadLinkIndex(const std::vector<unsigned char>& vchPubKey, uint256& txid);
+    bool EraseLinkIndex(const std::vector<unsigned char>& vchPubKey, const std::vector<unsigned char>& vchSharedPubKey);
+    bool LinkExists(const std::vector<unsigned char>& vchPubKey);
+    //bool CleanupIndexLinkDB(int& nRemoved);
 };
 
 bool UndoLinkData(const std::vector<unsigned char>& vchPubKey, const std::vector<unsigned char>& vchSharedPubKey);
-bool GetLinkRequestIndex(const std::vector<unsigned char>& vchPubKey, uint256& txid);
-bool GetLinkAcceptIndex(const std::vector<unsigned char>& vchPubKey, uint256& txid);
-bool CheckLinkRequestDB();
-bool CheckLinkAcceptDB();
-bool CheckLinkDBs();
-bool FlushLinkRequestDB();
-bool FlushLinkAcceptDB();
+bool GetLinkIndex(const std::vector<unsigned char>& vchPubKey, uint256& txid);
+bool CheckLinkDB();
+bool FlushLinkDB();
 bool CheckLinkTx(const CTransactionRef& tx, const int& op1, const int& op2, const std::vector<std::vector<unsigned char> >& vvchArgs, 
                                 const bool fJustCheck, const int& nHeight, const uint32_t& nBlockTime, const bool bSanityCheck, std::string& errorMessage);
 
 bool CheckPreviousLinkInputs(const std::string& strOpType, const CScript& scriptOp, const std::vector<std::vector<unsigned char>>& vvchOpParameters, std::string& errorMessage, bool fJustCheck);
 
-extern CLinkRequestDB *pLinkRequestDB;
-extern CLinkAcceptDB *pLinkAcceptDB;
+extern CLinkDB *pLinkDB;
 
 #endif // DYNAMIC_BDAP_LINKINGDB_H

--- a/src/bdap/linkingdb.h
+++ b/src/bdap/linkingdb.h
@@ -34,6 +34,8 @@ bool CheckLinkTx(const CTransactionRef& tx, const int& op1, const int& op2, cons
 
 bool CheckPreviousLinkInputs(const std::string& strOpType, const CScript& scriptOp, const std::vector<std::vector<unsigned char>>& vvchOpParameters, std::string& errorMessage, bool fJustCheck);
 
+bool LinkPubKeyExists(const std::vector<unsigned char>& vchPubKey);
+
 extern CLinkDB *pLinkDB;
 
 #endif // DYNAMIC_BDAP_LINKINGDB_H

--- a/src/bdap/rpclinking.cpp
+++ b/src/bdap/rpclinking.cpp
@@ -919,8 +919,9 @@ static UniValue DenyLink(const JSONRPCRequest& request)
         throw std::runtime_error("BDAP_DENY_LINK_RPC_ERROR: ERRCODE: 4246 - List is too large for one record in the DHT. " + _("\n"));
 
     iSequence++;
-    if (!DHT::SubmitPut(0, getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, newRecord))
-         throw std::runtime_error("BDAP_DENY_LINK_RPC_ERROR: ERRCODE: 4247 - Put failed. " + _("\n"));
+    std::string strErrorMessage;
+    if (!DHT::SubmitPut(getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, newRecord, strErrorMessage))
+        throw std::runtime_error("BDAP_DENY_LINK_RPC_ERROR: ERRCODE: 4247 - Put failed. " + strErrorMessage + _("\n"));
 
     oLink.push_back(Pair("recipient_fqdn", strRecipientFQDN));
     oLink.push_back(Pair("requestor_fqdn", strRequestorFQDN));

--- a/src/bdap/rpclinking.cpp
+++ b/src/bdap/rpclinking.cpp
@@ -172,7 +172,7 @@ static UniValue SendLinkRequest(const JSONRPCRequest& request)
 
     // Check if pubkey already exists
     uint256 prevTxID;
-    if (GetLinkRequestIndex(txLink.RequestorPubKey, prevTxID))
+    if (GetLinkIndex(txLink.RequestorPubKey, prevTxID))
         throw std::runtime_error("BDAP_SEND_LINK_RPC_ERROR: ERRCODE: 4003 - " + txLink.RequestorPubKeyString() + _(" entry already exists.  Can not add duplicate."));
 
     // Get requestor link address
@@ -349,7 +349,7 @@ static UniValue SendLinkAccept(const JSONRPCRequest& request)
 
     // Check if pubkey already exists
     uint256 prevTxID;
-    if (GetLinkAcceptIndex(txLinkAccept.RecipientPubKey, prevTxID))
+    if (GetLinkIndex(txLinkAccept.RecipientPubKey, prevTxID))
         throw std::runtime_error("BDAP_ACCEPT_LINK_RPC_ERROR: ERRCODE: 4105 - " + txLinkAccept.RecipientPubKeyString() + _(" entry already exists.  Can not add duplicate."));
 
     // Get link accepting address

--- a/src/bdap/rpclinking.cpp
+++ b/src/bdap/rpclinking.cpp
@@ -857,7 +857,7 @@ static UniValue DenyLink(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked();
 
-    if (!pHashTableSessionGet->Session)
+    if (!DHT::GetStatus(0) || !DHT::PutStatus(0))
         throw std::runtime_error("ERRORCODE: 5500 - DHT session not started.\n");
 
     std::string strRecipientFQDN = request.params[1].get_str() + "@" + DEFAULT_PUBLIC_OU + "." + DEFAULT_PUBLIC_DOMAIN;
@@ -884,7 +884,7 @@ static UniValue DenyLink(const JSONRPCRequest& request)
     int64_t iSequence = 0;
     bool fNotFound = false;
     CDataRecord record;
-    if (!pHashTableSessionGet->SubmitGetRecord(getKey.GetDHTPubKey(), getKey.GetDHTPrivSeed(), strOperationType, iSequence, record))
+    if (!DHT::SubmitGetRecord(0, getKey.GetDHTPubKey(), getKey.GetDHTPrivSeed(), strOperationType, iSequence, record))
         fNotFound = true;
 
     std::vector<unsigned char> vchSerializedList;
@@ -919,8 +919,8 @@ static UniValue DenyLink(const JSONRPCRequest& request)
         throw std::runtime_error("BDAP_DENY_LINK_RPC_ERROR: ERRCODE: 4246 - List is too large for one record in the DHT. " + _("\n"));
 
     iSequence++;
-    if (!pHashTableSessionGet->SubmitPut(getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, newRecord))
-        throw std::runtime_error("BDAP_DENY_LINK_RPC_ERROR: ERRCODE: 4247 - Put failed. " + pHashTableSessionGet->strPutErrorMessage + _("\n"));
+    if (!DHT::SubmitPut(0, getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, newRecord))
+         throw std::runtime_error("BDAP_DENY_LINK_RPC_ERROR: ERRCODE: 4247 - Put failed. " + _("\n"));
 
     oLink.push_back(Pair("recipient_fqdn", strRecipientFQDN));
     oLink.push_back(Pair("requestor_fqdn", strRequestorFQDN));
@@ -948,7 +948,7 @@ static UniValue DeniedLinkList(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked();
 
-    if (!pHashTableSessionGet->Session)
+    if (!DHT::GetStatus(0) || !DHT::PutStatus(0))
         throw std::runtime_error("ERRORCODE: 5500 - DHT session not started.\n");
 
     std::string strRecipientFQDN = request.params[1].get_str() + "@" + DEFAULT_PUBLIC_OU + "." + DEFAULT_PUBLIC_DOMAIN;
@@ -970,8 +970,8 @@ static UniValue DeniedLinkList(const JSONRPCRequest& request)
     std::string strOperationType = "denylink";
     int64_t iSequence = 0;
     CDataRecord record;
-    if (!pHashTableSessionGet->SubmitGetRecord(getKey.GetDHTPubKey(), getKey.GetDHTPrivSeed(), strOperationType, iSequence, record))
-        throw std::runtime_error(strprintf("%s: ERRCODE: 5604 - Failed to get record: %s\n", __func__, pHashTableSessionGet->strPutErrorMessage));
+    if (!DHT::SubmitGetRecord(0, getKey.GetDHTPubKey(), getKey.GetDHTPrivSeed(), strOperationType, iSequence, record))
+        throw std::runtime_error(strprintf("%s: ERRCODE: 5604 - Failed to get record\n", __func__));
 
     UniValue oDeniedLink(UniValue::VOBJ);
     CLinkDenyList denyList(record.RawData());

--- a/src/bdap/rpclinking.cpp
+++ b/src/bdap/rpclinking.cpp
@@ -857,7 +857,7 @@ static UniValue DenyLink(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked();
 
-    if (!pHashTableSession->Session)
+    if (!pHashTableSessionGet->Session)
         throw std::runtime_error("ERRORCODE: 5500 - DHT session not started.\n");
 
     std::string strRecipientFQDN = request.params[1].get_str() + "@" + DEFAULT_PUBLIC_OU + "." + DEFAULT_PUBLIC_DOMAIN;
@@ -884,7 +884,7 @@ static UniValue DenyLink(const JSONRPCRequest& request)
     int64_t iSequence = 0;
     bool fNotFound = false;
     CDataRecord record;
-    if (!pHashTableSession->SubmitGetRecord(getKey.GetDHTPubKey(), getKey.GetDHTPrivSeed(), strOperationType, iSequence, record))
+    if (!pHashTableSessionGet->SubmitGetRecord(getKey.GetDHTPubKey(), getKey.GetDHTPrivSeed(), strOperationType, iSequence, record))
         fNotFound = true;
 
     std::vector<unsigned char> vchSerializedList;
@@ -919,8 +919,8 @@ static UniValue DenyLink(const JSONRPCRequest& request)
         throw std::runtime_error("BDAP_DENY_LINK_RPC_ERROR: ERRCODE: 4246 - List is too large for one record in the DHT. " + _("\n"));
 
     iSequence++;
-    if (!pHashTableSession->SubmitPut(getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, newRecord))
-        throw std::runtime_error("BDAP_DENY_LINK_RPC_ERROR: ERRCODE: 4247 - Put failed. " + pHashTableSession->strPutErrorMessage + _("\n"));
+    if (!pHashTableSessionGet->SubmitPut(getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, newRecord))
+        throw std::runtime_error("BDAP_DENY_LINK_RPC_ERROR: ERRCODE: 4247 - Put failed. " + pHashTableSessionGet->strPutErrorMessage + _("\n"));
 
     oLink.push_back(Pair("recipient_fqdn", strRecipientFQDN));
     oLink.push_back(Pair("requestor_fqdn", strRequestorFQDN));
@@ -948,7 +948,7 @@ static UniValue DeniedLinkList(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked();
 
-    if (!pHashTableSession->Session)
+    if (!pHashTableSessionGet->Session)
         throw std::runtime_error("ERRORCODE: 5500 - DHT session not started.\n");
 
     std::string strRecipientFQDN = request.params[1].get_str() + "@" + DEFAULT_PUBLIC_OU + "." + DEFAULT_PUBLIC_DOMAIN;
@@ -970,8 +970,8 @@ static UniValue DeniedLinkList(const JSONRPCRequest& request)
     std::string strOperationType = "denylink";
     int64_t iSequence = 0;
     CDataRecord record;
-    if (!pHashTableSession->SubmitGetRecord(getKey.GetDHTPubKey(), getKey.GetDHTPrivSeed(), strOperationType, iSequence, record))
-        throw std::runtime_error(strprintf("%s: ERRCODE: 5604 - Failed to get record: %s\n", __func__, pHashTableSession->strPutErrorMessage));
+    if (!pHashTableSessionGet->SubmitGetRecord(getKey.GetDHTPubKey(), getKey.GetDHTPrivSeed(), strOperationType, iSequence, record))
+        throw std::runtime_error(strprintf("%s: ERRCODE: 5604 - Failed to get record: %s\n", __func__, pHashTableSessionGet->strPutErrorMessage));
 
     UniValue oDeniedLink(UniValue::VOBJ);
     CLinkDenyList denyList(record.RawData());

--- a/src/bdap/rpclinking.cpp
+++ b/src/bdap/rpclinking.cpp
@@ -857,7 +857,7 @@ static UniValue DenyLink(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked();
 
-    if (!DHT::GetStatus(0) || !DHT::PutStatus(0))
+    if (!DHT::SessionStatus())
         throw std::runtime_error("ERRORCODE: 5500 - DHT session not started.\n");
 
     std::string strRecipientFQDN = request.params[1].get_str() + "@" + DEFAULT_PUBLIC_OU + "." + DEFAULT_PUBLIC_DOMAIN;
@@ -949,7 +949,7 @@ static UniValue DeniedLinkList(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked();
 
-    if (!DHT::GetStatus(0) || !DHT::PutStatus(0))
+    if (!DHT::SessionStatus())
         throw std::runtime_error("ERRORCODE: 5500 - DHT session not started.\n");
 
     std::string strRecipientFQDN = request.params[1].get_str() + "@" + DEFAULT_PUBLIC_OU + "." + DEFAULT_PUBLIC_DOMAIN;

--- a/src/dht/datarecord.cpp
+++ b/src/dht/datarecord.cpp
@@ -167,7 +167,13 @@ bool CDataRecord::InitGet(const std::vector<unsigned char>& privateKey)
     for(unsigned int i = 0; i < dataHeader.nChunks; i++) {
         vchChunks.insert(vchChunks.end(), vChunks[i].vchValue.begin(), vChunks[i].vchValue.end());
     }
-    std::vector<unsigned char> vchUnHexValue = ParseHex(stringFromVch(vchChunks));
+    std::vector<unsigned char> vchUnHexValue;
+    std::string strChunk = stringFromVch(vchChunks);
+    if (IsHex(strChunk)) {
+        vchUnHexValue = ParseHex(strChunk);
+    } else {
+        vchUnHexValue = vchChunks;
+    }
     if (vchUnHexValue.size() != dataHeader.nDataSize)
     {
         LogPrintf("CDataRecord::%s --Warning, data size in header (%d) mismatches the total size (%d) from all chunks (%d).\n", __func__, dataHeader.nDataSize, vchUnHexValue.size(), dataHeader.nChunks);

--- a/src/dht/datarecord.h
+++ b/src/dht/datarecord.h
@@ -47,7 +47,7 @@ public:
     std::string OperationCode() const { return strOperationCode; }
     uint16_t TotalSlots() const { return nTotalSlots; }
     std::vector<unsigned char> RawData() const { return vchData; }
-    CRecordHeader GetHeader() { return dataHeader; }
+    CRecordHeader GetHeader() const { return dataHeader; }
     bool Encrypted() { return dataHeader.Encrypted(); }
     uint16_t Version() { return dataHeader.nVersion; }
 

--- a/src/dht/datarecord.h
+++ b/src/dht/datarecord.h
@@ -64,7 +64,8 @@ private:
     bool InitGet(const std::vector<unsigned char>& privateKey);
 };
 
-class CDataRecordBuffer{
+class CDataRecordBuffer
+{
 public:
     CDataRecordBuffer(size_t size);
     void push_back(const CDataRecord& input);

--- a/src/dht/ed25519.cpp
+++ b/src/dht/ed25519.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "ed25519.h"
+#include "dht/ed25519.h"
 
 #include "hash.h"
 #include "random.h"

--- a/src/dht/limits.cpp
+++ b/src/dht/limits.cpp
@@ -4,6 +4,9 @@
 
 #include "dht/limits.h"
 
+#include "bdap/domainentrydb.h"
+#include "bdap/linkingdb.h"
+#include "chain.h"
 #include "utilstrencodings.h"
 #include "tinyformat.h"
 
@@ -71,5 +74,15 @@ bool CheckSalt(const std::string& strSalt, const unsigned int nHeight, std::stri
         return true;
     }
     strErrorMessage = strprintf("%s, Invalid salt. Allow data type salt not found in allowed data map.", strErrorMessage);
+    return false;
+}
+
+bool CheckPubKey(const std::vector<unsigned char>& vchPubKey)
+{
+    bool fAccountPubkey = AccountPubKeyExists(vchPubKey);
+    bool fLinkPubkey = LinkPubKeyExists(vchPubKey);
+    if (fAccountPubkey || fLinkPubkey)
+        return true;
+
     return false;
 }

--- a/src/dht/limits.cpp
+++ b/src/dht/limits.cpp
@@ -70,7 +70,6 @@ bool CheckSalt(const std::string& strSalt, const unsigned int nHeight, std::stri
             iAllowed++;
             continue;
         }
-        LogPrintf("%s -- Salt %s passed all checks. Valid data record salt\n", __func__, strSalt);
         return true;
     }
     strErrorMessage = strprintf("%sInvalid salt (%s). Allow data type salt not found in allowed data map.", strErrorMessage, vSplit[0]);

--- a/src/dht/limits.cpp
+++ b/src/dht/limits.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2019 Duality Blockchain Solutions Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "dht/limits.h"
+
+#include "utilstrencodings.h"
+#include "tinyformat.h"
+
+#include <boost/algorithm/string.hpp>
+
+#include <map>
+#include <vector>
+
+//  Default accepted DHT record types:
+std::multimap<std::string, CAllowDataCode> mapAllowedData = {
+    //                             salt,       slots,  start, expire
+    {"info",        CAllowDataCode("info",     32,     0,     0)}, 
+    {"denylink",    CAllowDataCode("denylink", 32,     0,     0)},
+    {"ignore",      CAllowDataCode("ignore",   32,     0,     0)},
+    {"index",       CAllowDataCode("index",    32,     0,     0)},
+    {"avatar",      CAllowDataCode("avatar",    4,     0,     0)},
+    {"ldap",        CAllowDataCode("ldap",     32,     0,     0)},
+    {"oauth",       CAllowDataCode("oauth",    16,     0,     0)},
+    {"pshare",      CAllowDataCode("pshare",   48,     0,     0)},
+    {"pconsult",    CAllowDataCode("pconsult", 48,     0,     0)},
+    {"noid",        CAllowDataCode("noid",     48,     0,     0)},
+    {"whispers",    CAllowDataCode("whispers", 48,     0,     0)},
+    {"spam",        CAllowDataCode("spam",     64,     0,     0)},
+    {"groups",      CAllowDataCode("groups",   48,     0,     0)},
+    {"chat",        CAllowDataCode("chat",     32,     0,     0)},
+    {"message",     CAllowDataCode("message",  32,     0,     0)},
+    {"data",        CAllowDataCode("data",    128,     0,     0)},
+    {"keys",        CAllowDataCode("keys",     32,     0,     0)},
+    {"test",        CAllowDataCode("test",      8,     0,     0)},
+};
+
+
+bool CheckSalt(const std::string& strSalt, const unsigned int nHeight, std::string& strErrorMessage)
+{
+    strErrorMessage = "";
+    std::vector<std::string> vSplit;
+    boost::split(vSplit, strSalt, boost::is_any_of(":"));
+    if (vSplit.size() != 2) {
+        strErrorMessage = strprintf("Invalid salt (%s). Could not find ':' delimiter", strSalt);
+        return false;
+    }
+    uint32_t nSlots;
+    if (ParseUInt32(vSplit[1], &nSlots)) {
+        strErrorMessage = strprintf("Invalid salt (%s). Could not parse slot number after :", strSalt);
+        return false;
+    }
+    std::multimap<std::string, CAllowDataCode>::iterator iAllowed = mapAllowedData.find(vSplit[0]);
+    while (iAllowed != mapAllowedData.end()) {
+        if (nHeight > iAllowed->second.nStartHeight) {
+            strErrorMessage = strprintf("%s, Allow data type found but height is greater than allowed data start height %d. ", strErrorMessage, iAllowed->second.nStartHeight);
+            iAllowed++;
+            continue;
+        }
+        if (iAllowed->second.nExpireTime >= nHeight && iAllowed->second.nExpireTime != 0) {
+            strErrorMessage = strprintf("%s, Allow data type found but expired %d. ", strErrorMessage, iAllowed->second.nExpireTime);
+            iAllowed++;
+            continue;
+        }
+        if (nSlots <= iAllowed->second.nMaximumSlots) {
+            strErrorMessage = strprintf("%s, Allow data type found but too many slots (%d) used. Max slots = %d", strErrorMessage, nSlots, iAllowed->second.nMaximumSlots);
+            iAllowed++;
+            continue;
+        }
+        // Passes all checks so it is a valid data record salt.
+        return true;
+    }
+    strErrorMessage = strprintf("%s, Invalid salt. Allow data type salt not found in allowed data map.", strErrorMessage);
+    return false;
+}

--- a/src/dht/limits.h
+++ b/src/dht/limits.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2019 Duality Blockchain Solutions Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef DYNAMIC_DHT_LIMITS_H
+#define DYNAMIC_DHT_LIMITS_H
+
+/**!
+These limit classes define allowed salts (records) that the DHT will accept for storage.
+The first version contains a list of acceptable salts but in future versions, this list will
+be dynamic.  Application developers that want to store data in the DHT can purchase certificate
+that allow their custom op code.
+*/
+
+#include <string>
+
+class CAllowDataCode {
+public:
+    std::string strSalt;
+    uint32_t nMaximumSlots;
+    unsigned int nStartHeight;
+    uint64_t nExpireTime;
+
+    CAllowDataCode(const std::string& salt, const uint32_t maxslots, const unsigned int& start, const uint64_t expire) :
+        strSalt(salt), nMaximumSlots(maxslots), nStartHeight(start), nExpireTime(expire) {}
+
+};
+
+bool CheckSalt(const std::string& strSalt, const unsigned int nHeight, std::string& strErrorMessage);
+
+
+#endif // DYNAMIC_DHT_LIMITS_H

--- a/src/dht/limits.h
+++ b/src/dht/limits.h
@@ -8,11 +8,12 @@
 /**!
 These limit classes define allowed salts (records) that the DHT will accept for storage.
 The first version contains a list of acceptable salts but in future versions, this list will
-be dynamic.  Application developers that want to store data in the DHT can purchase certificate
-that allow their custom op code.
+be dynamic.  Application developers that want to store data in the DHT can purchase a certificate
+that allows their custom op code.
 */
 
 #include <string>
+#include <vector>
 
 class CAllowDataCode {
 public:
@@ -27,6 +28,6 @@ public:
 };
 
 bool CheckSalt(const std::string& strSalt, const unsigned int nHeight, std::string& strErrorMessage);
-
+bool CheckPubKey(const std::vector<unsigned char>& vchPubKey);
 
 #endif // DYNAMIC_DHT_LIMITS_H

--- a/src/dht/mutable.cpp
+++ b/src/dht/mutable.cpp
@@ -7,6 +7,7 @@
 #include "bdap/utils.h"
 #include "hash.h"
 #include "streams.h"
+#include "tinyformat.h"
 
 #include <univalue.h>
 
@@ -62,4 +63,10 @@ std::string CMutableData::Salt() const
 std::string CMutableData::Value() const
 {
     return stringFromVch(vchValue);
+}
+
+std::string CMutableData::ToString() const
+{
+    return strprintf("CMutableData(InfoHash = %s\n, PublicKey = %s\n, Salt = %s\n, Signature = %s\n, Value = %s)\n",
+        InfoHash(), PublicKey(), Salt(), Signature(), Value());
 }

--- a/src/dht/mutable.cpp
+++ b/src/dht/mutable.cpp
@@ -67,6 +67,6 @@ std::string CMutableData::Value() const
 
 std::string CMutableData::ToString() const
 {
-    return strprintf("CMutableData(InfoHash = %s\n, PublicKey = %s\n, Salt = %s\n, Signature = %s\n, Value = %s)\n",
-        InfoHash(), PublicKey(), Salt(), Signature(), Value());
+    return strprintf("CMutableData(\nInfoHash = %s\n, PublicKey = %s\n, Salt = %s\n, Seq = %d\n, Signature = %s\n, Value = %s)\n",
+        InfoHash(), PublicKey(), Salt(), SequenceNumber, Signature(), Value());
 }

--- a/src/dht/mutable.h
+++ b/src/dht/mutable.h
@@ -81,6 +81,8 @@ public:
     std::string Signature() const;
     std::string Salt() const;
     std::string Value() const;
+    std::string ToString() const;
+
 };
 
 #endif // DYNAMIC_DHT_MUTABLE_DATA_H

--- a/src/dht/mutabledb.cpp
+++ b/src/dht/mutabledb.cpp
@@ -106,6 +106,14 @@ bool SelectRandomMutableItem(CMutableData& randomItem)
     return true;
 }
 
+bool CheckMutableItemDB()
+{
+    if (!pMutableDataDB)
+        return false;
+
+    return true;
+}
+
 bool CMutableDataDB::AddMutableData(const CMutableData& data)
 {
     bool writeState = false;

--- a/src/dht/mutabledb.cpp
+++ b/src/dht/mutabledb.cpp
@@ -202,15 +202,16 @@ bool CMutableDataDB::LoadMemoryMap()
     return true;
 }
 
-bool CMutableDataDB::SelectRandomMutableItem(CMutableData& randomItem)
-{
-    if (count == -1 || count == 0)
+bool CMutableDataDB::SelectRandomMutableItem(CMutableData& randomItem) {
+    if (count < 1)
         return false;
 
+    unsigned int nAdvance = 0;
     std::map<std::vector<unsigned char>, CMutableData>::iterator it = mapDataStorage.begin();
-    unsigned int nRandomItem = RandomIntegerRange(0, count - 1);
-    std::advance(it, nRandomItem);
+    if (count != 1) {
+        nAdvance = RandomIntegerRange(0, count - 1);
+    }
+    std::advance(it, nAdvance);
     randomItem = it->second;
-
     return true;
 }

--- a/src/dht/mutabledb.cpp
+++ b/src/dht/mutabledb.cpp
@@ -5,10 +5,15 @@
 #include "dht/mutabledb.h"
 
 #include "dht/mutable.h"
+#include "util.h"
 
 #include <univalue.h>
 
 #include <boost/thread.hpp>
+
+#include "map"
+
+static std::map<std::vector<unsigned char>, CMutableData> mapDataStorage;
 
 CMutableDataDB *pMutableDataDB = NULL;
 
@@ -79,18 +84,50 @@ bool GetAllLocalMutableData(std::vector<CMutableData>& vchMutableData)
     return true;
 }
 
+bool InitMemoryMap()
+{
+    if (!pMutableDataDB)
+        return false;
+
+    if (!pMutableDataDB->LoadMemoryMap())
+        return false;
+
+    return true;
+}
+
+bool SelectRandomMutableItem(CMutableData& randomItem)
+{
+    if (!pMutableDataDB)
+        return false;
+
+    if (!pMutableDataDB->SelectRandomMutableItem(randomItem))
+        return false;
+
+    return true;
+}
+
 bool CMutableDataDB::AddMutableData(const CMutableData& data)
 {
     bool writeState = false;
     {
         LOCK(cs_dht_entry);
         writeState = CDBWrapper::Write(make_pair(std::string("ih"), data.vchInfoHash), data);  // use info hash as key
+        if (count >= 0) {
+            mapDataStorage[data.vchInfoHash] = data;
+            count++;
+        }
     }
     return writeState;
 }
 
 bool CMutableDataDB::ReadMutableData(const std::vector<unsigned char>& vchInfoHash, CMutableData& data)
 {
+    if (count >= 0) {
+        data = mapDataStorage[vchInfoHash];
+        if (!data.IsNull())
+            return true;
+    }
+
     LOCK(cs_dht_entry);
     return CDBWrapper::Read(make_pair(std::string("ih"), vchInfoHash), data);
 }
@@ -98,6 +135,9 @@ bool CMutableDataDB::ReadMutableData(const std::vector<unsigned char>& vchInfoHa
 bool CMutableDataDB::EraseMutableData(const std::vector<unsigned char>& vchInfoHash)
 {
     LOCK(cs_dht_entry);
+    if (count >= 0)
+        mapDataStorage.erase(vchInfoHash);
+
     return CDBWrapper::Erase(make_pair(std::string("ih"), vchInfoHash));
 }
 
@@ -110,6 +150,9 @@ bool CMutableDataDB::UpdateMutableData(const CMutableData& data)
 
     bool writeState = false;
     writeState = CDBWrapper::Update(make_pair(std::string("ih"), data.vchInfoHash), data);
+    if (count >= 0)
+        mapDataStorage[data.vchInfoHash] = data;
+
     return writeState;
 }
 
@@ -132,5 +175,42 @@ bool CMutableDataDB::ListMutableData(std::vector<CMutableData>& vchMutableData)
             return error("%s() : deserialize error", __PRETTY_FUNCTION__);
         }
     }
+    return true;
+}
+
+bool CMutableDataDB::LoadMemoryMap()
+{
+    std::pair<std::string, CharString> infoHash;
+    std::unique_ptr<CDBIterator> pcursor(NewIterator());
+    pcursor->SeekToFirst();
+    count = 0;
+    while (pcursor->Valid()) {
+        boost::this_thread::interruption_point();
+        CMutableData data;
+        try {
+            if (pcursor->GetKey(infoHash) && infoHash.first == "ih") {
+                pcursor->GetValue(data);
+                mapDataStorage[infoHash.second] = data;
+            }
+            pcursor->Next();
+            count++;
+        }
+        catch (std::exception& e) {
+            return error("%s() : deserialize error", __PRETTY_FUNCTION__);
+        }
+    }
+    return true;
+}
+
+bool CMutableDataDB::SelectRandomMutableItem(CMutableData& randomItem)
+{
+    if (count == -1 || count == 0)
+        return false;
+
+    std::map<std::vector<unsigned char>, CMutableData>::iterator it = mapDataStorage.begin();
+    unsigned int nRandomItem = RandomIntegerRange(0, count - 1);
+    std::advance(it, nRandomItem);
+    randomItem = it->second;
+
     return true;
 }

--- a/src/dht/mutabledb.h
+++ b/src/dht/mutabledb.h
@@ -38,6 +38,7 @@ bool PutLocalMutableData(const std::vector<unsigned char>& vchInfoHash, const CM
 bool GetAllLocalMutableData(std::vector<CMutableData>& vchMutableData);
 bool InitMemoryMap();
 bool SelectRandomMutableItem(CMutableData& randomItem);
+bool CheckMutableItemDB();
 
 extern CMutableDataDB* pMutableDataDB;
 

--- a/src/dht/mutabledb.h
+++ b/src/dht/mutabledb.h
@@ -22,6 +22,13 @@ public:
     bool ReadMutableData(const std::vector<unsigned char>& vchInfoHash, CMutableData& data);
     bool EraseMutableData(const std::vector<unsigned char>& vchInfoHash);
     bool ListMutableData(std::vector<CMutableData>& vchMutableData);
+    bool LoadMemoryMap();
+    bool SelectRandomMutableItem(CMutableData& randomItem);
+    int64_t Size() const { return count; }
+
+private:
+	int64_t count = -1;
+
 };
 
 bool AddLocalMutableData(const std::vector<unsigned char>& vchInfoHash, const CMutableData& data);
@@ -29,6 +36,8 @@ bool UpdateLocalMutableData(const std::vector<unsigned char>& vchInfoHash, const
 bool GetLocalMutableData(const std::vector<unsigned char>& vchInfoHash, CMutableData& data);
 bool PutLocalMutableData(const std::vector<unsigned char>& vchInfoHash, const CMutableData& data);
 bool GetAllLocalMutableData(std::vector<CMutableData>& vchMutableData);
+bool InitMemoryMap();
+bool SelectRandomMutableItem(CMutableData& randomItem);
 
 extern CMutableDataDB* pMutableDataDB;
 

--- a/src/dht/rpcdht.cpp
+++ b/src/dht/rpcdht.cpp
@@ -214,78 +214,23 @@ static UniValue GetDHTStatus(const JSONRPCRequest& request)
     if (!DHT::SessionStatus())
         throw JSONRPCError(RPC_DHT_NOT_STARTED, strprintf("dht %s failed. DHT session not started.", request.params[0].get_str()));
 
-    libtorrent::session_status stats;
-    std::vector<libtorrent::dht_lookup> vchDHTLookup; 
-    std::vector<libtorrent::dht_routing_bucket> vchDHTBuckets;
-    DHT::GetDHTStats(0, stats, vchDHTLookup, vchDHTBuckets);
-
+    CSessionStats stats;
+    DHT::GetDHTStats(stats);
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("num_peers", stats.num_peers));
-    result.push_back(Pair("peerlist_size", stats.peerlist_size));
-    result.push_back(Pair("active_request_size", (int)stats.active_requests.size()));
-    result.push_back(Pair("dht_node_cache", stats.dht_node_cache));
-    result.push_back(Pair("dht_global_nodes", stats.dht_global_nodes));
-    result.push_back(Pair("dht_download_rate", stats.dht_download_rate));
-    result.push_back(Pair("dht_upload_rate", stats.dht_upload_rate));
-    result.push_back(Pair("dht_total_allocations", stats.dht_total_allocations));
-    result.push_back(Pair("download_rate", stats.download_rate));
-    result.push_back(Pair("upload_rate", stats.upload_rate));
-    result.push_back(Pair("total_download", stats.total_download));
-    result.push_back(Pair("total_upload", stats.total_upload));
-    result.push_back(Pair("total_dht_download", stats.total_dht_download));
-    result.push_back(Pair("total_dht_upload", stats.total_dht_upload));
-    result.push_back(Pair("total_ip_overhead_download", stats.total_ip_overhead_download));
-    result.push_back(Pair("total_ip_overhead_upload", stats.total_ip_overhead_upload));
-    result.push_back(Pair("total_payload_download", stats.total_payload_download));
-    result.push_back(Pair("total_payload_upload", stats.total_payload_upload));
-    result.push_back(Pair("dht_nodes", stats.dht_nodes));
-    result.push_back(Pair("dht_torrents", stats.dht_torrents));
+    result.push_back(Pair("num_sessions", stats.nSessions));
+    result.push_back(Pair("put_records", stats.nPutRecords));
+    result.push_back(Pair("put_pieces", stats.nPutPieces));
+    result.push_back(Pair("put_bytes", stats.nPutBytes));
+    result.push_back(Pair("get_records", stats.nGetRecords));
+    result.push_back(Pair("get_pieces", stats.nGetPieces));
+    result.push_back(Pair("get_bytes", stats.nGetBytes));
+    result.push_back(Pair("get_errors", stats.nGetErrors));
 
-    for (const libtorrent::dht_routing_bucket& bucket : vchDHTBuckets){
-        UniValue oBucket(UniValue::VOBJ);
-        oBucket.push_back(Pair("num_nodes", bucket.num_nodes));
-        oBucket.push_back(Pair("num_replacements", bucket.num_replacements));
-        oBucket.push_back(Pair("last_active", bucket.last_active));
-        result.push_back(Pair("bucket", oBucket)); 
+    for (const std::pair<std::string, std::string>& pairMessage : stats.vMessages)
+    {
+        result.push_back(Pair(pairMessage.first, pairMessage.second));
     }
 
-    for (const libtorrent::dht_lookup& lookup : vchDHTLookup) {
-        UniValue oLookup(UniValue::VOBJ);
-        oLookup.push_back(Pair("outstanding_requests", lookup.outstanding_requests));
-        oLookup.push_back(Pair("timeouts", lookup.timeouts));
-        oLookup.push_back(Pair("responses", lookup.responses));
-        oLookup.push_back(Pair("branch_factor", lookup.branch_factor));
-        oLookup.push_back(Pair("nodes_left", lookup.nodes_left));
-        oLookup.push_back(Pair("last_sent", lookup.last_sent));
-        oLookup.push_back(Pair("first_timeout", lookup.first_timeout));
-        // string literal indicating which kind of lookup this is
-        // char const* type;
-        // the node-id or info-hash target for this lookup
-        //sha1_hash target;
-        result.push_back(oLookup);
-        result.push_back(Pair("lookup", oLookup)); 
-    }
-/*
-    result.push_back(Pair("ip_overhead_download_rate", stats.ip_overhead_download_rate));
-    result.push_back(Pair("ip_overhead_upload_rate", stats.ip_overhead_upload_rate));
-    result.push_back(Pair("payload_download_rate", stats.payload_download_rate));
-    result.push_back(Pair("payload_upload_rate", stats.payload_upload_rate));
-    result.push_back(Pair("tracker_upload_rate", stats.tracker_upload_rate));
-    result.push_back(Pair("tracker_download_rate", stats.tracker_download_rate));
-    result.push_back(Pair("total_tracker_download", stats.total_tracker_download));
-    result.push_back(Pair("total_tracker_upload", stats.total_tracker_upload));
-    result.push_back(Pair("total_redundant_bytes", stats.total_redundant_bytes));
-    result.push_back(Pair("total_failed_bytes", stats.total_failed_bytes));
-    result.push_back(Pair("num_unchoked", stats.num_unchoked));
-    result.push_back(Pair("allowed_upload_slots", stats.allowed_upload_slots));
-    result.push_back(Pair("up_bandwidth_queue", stats.up_bandwidth_queue));
-    result.push_back(Pair("down_bandwidth_queue", stats.down_bandwidth_queue));
-    result.push_back(Pair("up_bandwidth_bytes_queue", stats.up_bandwidth_bytes_queue));
-    result.push_back(Pair("down_bandwidth_bytes_queue", stats.down_bandwidth_bytes_queue));
-    result.push_back(Pair("optimistic_unchoke_counter", stats.optimistic_unchoke_counter));
-    result.push_back(Pair("unchoke_counter", stats.unchoke_counter));
-    result.push_back(Pair("has_incoming_connections", stats.has_incoming_connections));
-*/
     return result;
 }
 

--- a/src/dht/rpcdht.cpp
+++ b/src/dht/rpcdht.cpp
@@ -323,7 +323,7 @@ UniValue dhtdb(const JSONRPCRequest& request)
             oMutableData.push_back(Pair("signature", data.Signature()));
             oMutableData.push_back(Pair("seq_num", data.SequenceNumber));
             oMutableData.push_back(Pair("salt", data.Salt()));
-            oMutableData.push_back(Pair("value", data.Value()));
+            oMutableData.push_back(Pair("value", EncodeBase64(data.Value())));
             result.push_back(Pair("dht_entry_" + std::to_string(nCounter + 1), oMutableData));
             nCounter++;
         }

--- a/src/dht/rpcdht.cpp
+++ b/src/dht/rpcdht.cpp
@@ -214,7 +214,7 @@ static UniValue GetDHTStatus(const JSONRPCRequest& request)
     libtorrent::session_status stats;
     std::vector<libtorrent::dht_lookup> vchDHTLookup; 
     std::vector<libtorrent::dht_routing_bucket> vchDHTBuckets;
-    GetDHTStats(stats, vchDHTLookup, vchDHTBuckets);
+    pHashTableSession->GetDHTStats(stats, vchDHTLookup, vchDHTBuckets);
 
     UniValue result(UniValue::VOBJ);
     result.push_back(Pair("num_peers", stats.num_peers));
@@ -692,7 +692,7 @@ UniValue dhtgetmessages(const JSONRPCRequest& request)
     UniValue result(UniValue::VOBJ);
 
     std::vector<CMutableGetEvent> vchMutableData;
-    bool fRet = GetAllDHTGetEvents(vchMutableData);
+    bool fRet = pHashTableSession->GetAllDHTGetEvents(vchMutableData);
     int nCounter = 0;
     if (fRet) {
         for(const CMutableGetEvent& data : vchMutableData) {

--- a/src/dht/rpcdht.cpp
+++ b/src/dht/rpcdht.cpp
@@ -55,7 +55,7 @@ static UniValue GetMutable(const JSONRPCRequest& request)
 
     UniValue result(UniValue::VOBJ);
 
-    if (!DHT::GetStatus(0))
+    if (!DHT::SessionStatus())
         throw JSONRPCError(RPC_DHT_NOT_STARTED, strprintf("dht %s failed. DHT session not started.", request.params[0].get_str()));
 
     const std::string strPubKey = request.params[1].get_str();
@@ -108,7 +108,7 @@ static UniValue PutMutable(const JSONRPCRequest& request)
 
     UniValue result(UniValue::VOBJ);
 
-    if (!DHT::PutStatus(0))
+    if (!DHT::SessionStatus())
         throw JSONRPCError(RPC_DHT_NOT_STARTED, strprintf("dht %s failed. DHT session not started.", request.params[0].get_str()));
 
     //TODO: Check putValue is not > 1000 bytes.
@@ -211,7 +211,7 @@ static UniValue GetDHTStatus(const JSONRPCRequest& request)
            "\nAs a JSON-RPC call\n" + 
            HelpExampleRpc("dhtinfo", ""));
 
-    if (!DHT::GetStatus(0) || !DHT::PutStatus(0))
+    if (!DHT::SessionStatus())
         throw JSONRPCError(RPC_DHT_NOT_STARTED, strprintf("dht %s failed. DHT session not started.", request.params[0].get_str()));
 
     libtorrent::session_status stats;
@@ -367,7 +367,7 @@ static UniValue PutRecord(const JSONRPCRequest& request)
 
     UniValue result(UniValue::VOBJ);
 
-    if (!DHT::PutStatus(0))
+    if (!DHT::SessionStatus())
         throw JSONRPCError(RPC_DHT_NOT_STARTED, strprintf("dht %s failed. DHT session not started.", request.params[0].get_str()));
 
     if (!CheckDomainEntryDB())
@@ -470,7 +470,7 @@ static UniValue ClearRecord(const JSONRPCRequest& request)
 
     UniValue result(UniValue::VOBJ);
 
-    if (!DHT::GetStatus(0) || !DHT::PutStatus(0))
+    if (!DHT::SessionStatus())
         throw JSONRPCError(RPC_DHT_NOT_STARTED, strprintf("dht %s failed. DHT session not started.", request.params[0].get_str()));
 
     if (!CheckDomainEntryDB())
@@ -564,7 +564,7 @@ static UniValue GetRecord(const JSONRPCRequest& request)
     int64_t nStart = GetTimeMillis();
     UniValue result(UniValue::VOBJ);
    
-    if (!DHT::GetStatus(0))
+    if (!DHT::SessionStatus())
         throw JSONRPCError(RPC_DHT_NOT_STARTED, strprintf("dht %s failed. DHT session not started.", request.params[0].get_str()));
 
     if (!CheckDomainEntryDB())
@@ -753,7 +753,7 @@ static UniValue GetLinkRecord(const JSONRPCRequest& request)
     int64_t nStart = GetTimeMillis();
     UniValue result(UniValue::VOBJ);
 
-    if (!DHT::GetStatus(0))
+    if (!DHT::SessionStatus())
         throw JSONRPCError(RPC_DHT_NOT_STARTED, strprintf("dht %s failed. DHT session not started.", request.params[0].get_str()));
 
     if (!CheckDomainEntryDB())
@@ -870,7 +870,7 @@ static UniValue GetAllLinkRecords(const JSONRPCRequest& request)
 
     UniValue results(UniValue::VOBJ);
    
-    if (!DHT::GetStatus(0))
+    if (!DHT::SessionStatus())
         throw JSONRPCError(RPC_DHT_NOT_STARTED, strprintf("dht %s failed. DHT session not started.", request.params[0].get_str()));
 
     if (!CheckDomainEntryDB())
@@ -956,7 +956,7 @@ static UniValue PutLinkRecord(const JSONRPCRequest& request)
 
     UniValue result(UniValue::VOBJ);
 
-    if (!DHT::GetStatus(0) || !DHT::PutStatus(0))
+    if (!DHT::SessionStatus())
         throw JSONRPCError(RPC_DHT_NOT_STARTED, strprintf("dht %s failed. DHT session not started.", request.params[0].get_str()));
 
     if (!CheckDomainEntryDB())
@@ -1083,7 +1083,7 @@ static UniValue ClearLinkRecord(const JSONRPCRequest& request)
 
     UniValue result(UniValue::VOBJ);
 
-    if (!DHT::PutStatus(0))
+    if (!DHT::SessionStatus())
         throw JSONRPCError(RPC_DHT_NOT_STARTED, strprintf("dht %s failed. DHT session not started.", request.params[0].get_str()));
 
     if (!CheckDomainEntryDB())

--- a/src/dht/rpcdht.cpp
+++ b/src/dht/rpcdht.cpp
@@ -155,9 +155,9 @@ static UniValue PutMutable(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_DHT_GET_FAILED, strprintf("Error creating DHT data entry. %s", record.ErrorMessage()));
 
     record.GetHeader().Salt = strOperationType;
-
-    if (!DHT::SubmitPut(0, key.GetDHTPubKey(), key.GetDHTPrivKey(), iSequence, record))
-        throw JSONRPCError(RPC_DHT_PUT_FAILED, strprintf("Put failed."));
+    std::string strErrorMessage;
+    if (!DHT::SubmitPut(key.GetDHTPubKey(), key.GetDHTPrivKey(), iSequence, record, strErrorMessage))
+        throw JSONRPCError(RPC_DHT_PUT_FAILED, strprintf("Put failed. %s", strErrorMessage));
 
     result.push_back(Pair("put_seq", iSequence));
     result.push_back(Pair("put_data_size", (int)vchValue.size()));
@@ -433,8 +433,9 @@ static UniValue PutRecord(const JSONRPCRequest& request)
     if (record.HasError())
         throw JSONRPCError(RPC_DHT_INVALID_RECORD, strprintf("Error creating DHT data entry. %s", record.ErrorMessage()));
 
-    if (!DHT::SubmitPut(0, getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, record))
-        throw JSONRPCError(RPC_DHT_PUT_FAILED, strprintf("Put failed."));
+    std::string strErrorMessage;
+    if (!DHT::SubmitPut(getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, record, strErrorMessage))
+        throw JSONRPCError(RPC_DHT_PUT_FAILED, strprintf("Put failed. %s", strErrorMessage));
 
     result.push_back(Pair("put_seq", iSequence));
     result.push_back(Pair("put_data_size", (int)vchValue.size()));
@@ -525,8 +526,9 @@ static UniValue ClearRecord(const JSONRPCRequest& request)
     if (record.HasError())
         throw JSONRPCError(RPC_DHT_INVALID_RECORD, strprintf("Error creating DHT data entry. %s", record.ErrorMessage()));
 
-    if (!DHT::SubmitPut(0, getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, record))
-        throw JSONRPCError(RPC_DHT_PUT_FAILED, strprintf("Put failed"));
+    std::string strErrorMessage;
+    if (!DHT::SubmitPut(getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, record, strErrorMessage))
+        throw JSONRPCError(RPC_DHT_PUT_FAILED, strprintf("Put failed. %s", strErrorMessage));
 
     result.push_back(Pair("put_seq", iSequence));
     result.push_back(Pair("put_data_size", (int)vchValue.size()));
@@ -1044,8 +1046,9 @@ static UniValue PutLinkRecord(const JSONRPCRequest& request)
     if (record.HasError())
         throw JSONRPCError(RPC_DHT_INVALID_RECORD, strprintf("Error creating DHT data entry. %s", record.ErrorMessage()));
 
-    if (!DHT::SubmitPut(0, getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, record))
-        throw JSONRPCError(RPC_DHT_PUT_FAILED, strprintf("Put failed."));
+    std::string strErrorMessage;
+    if (!DHT::SubmitPut(getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, record, strErrorMessage))
+        throw JSONRPCError(RPC_DHT_PUT_FAILED, strprintf("Put failed. %s", strErrorMessage));
 
     result.push_back(Pair("put_seq", iSequence));
     result.push_back(Pair("put_data_size", (int)vchValue.size()));
@@ -1160,8 +1163,9 @@ static UniValue ClearLinkRecord(const JSONRPCRequest& request)
     if (record.HasError())
         throw JSONRPCError(RPC_DHT_INVALID_RECORD, strprintf("Error creating DHT data entry. %s", record.ErrorMessage()));
 
-    if (!DHT::SubmitPut(0, getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, record))
-        throw JSONRPCError(RPC_DHT_PUT_FAILED, strprintf("Put failed."));
+    std::string strErrorMessage;
+    if (!DHT::SubmitPut(getKey.GetDHTPubKey(), getKey.GetDHTPrivKey(), iSequence, record, strErrorMessage))
+        throw JSONRPCError(RPC_DHT_PUT_FAILED, strprintf("Put failed. %s", strErrorMessage));
 
     result.push_back(Pair("put_seq", iSequence));
     result.push_back(Pair("put_data_size", (int)vchValue.size()));

--- a/src/dht/session.cpp
+++ b/src/dht/session.cpp
@@ -270,8 +270,10 @@ void static StartDHTNetwork(const CChainParams& chainparams, CConnman& connman)
         size_t nRunningThreads = fMultiThreads ? nThreads : 1;
         // Dynodes use a fixed peer id for the DHT.
         std::string strDynodePeerID;
-        if (fDynodeMode)
-            strDynodePeerID = GetDynodeHashID(activeDynode.outpoint.ToStringShort());
+        if (fDynodeMode) {
+            MilliSleep(1000); // wait a second to make sure we have the Dynode service address loaded.
+            strDynodePeerID = GetDynodeHashID(activeDynode.service.ToString(false));
+        }
 
         if (nRunningThreads > 1) {
             for (unsigned int i = 0; i < nRunningThreads; i++) {

--- a/src/dht/session.cpp
+++ b/src/dht/session.cpp
@@ -246,10 +246,11 @@ void ReannounceEntries()
                     }
                     // TODO: Check if fewer than 8 nodes returned the item with the most recent sequence number before re-announcing item
                     libtorrent::entry mut_item;
-                    if (ConvertMutableEntry(randomMutableItem, mut_item)) {
+                    if (randomMutableItem.vchSalt.size() > 0 && ConvertMutableEntry(randomMutableItem, mut_item)) {
                         size_t thread = fMultiThreads ? nThreads -1 : 0;
+                        libtorrent::sha1_hash infohash(randomMutableItem.InfoHash().c_str());
                         arraySessions[thread].second->Session->dht_put_item(mut_item);
-                        LogPrintf("%s -- Re-annoucing mut_item %s\n", __func__, mut_item.to_string());
+                        LogPrintf("%s -- Re-annoucing item infohash %s, entry \n%s\n", __func__, infohash.to_string(), mut_item.to_string());
                     }
                 }
             }

--- a/src/dht/session.cpp
+++ b/src/dht/session.cpp
@@ -102,7 +102,7 @@ namespace DHT {
 void CHashTableSession::StopEventListener()
 {
     fShutdown = true;
-    LogPrintf("%s -- stopping.\n", __func__);
+    LogPrintf("%s -- stopping DHT session thread %s.\n", __func__, strName);
     MilliSleep(333);
 }
 

--- a/src/dht/session.cpp
+++ b/src/dht/session.cpp
@@ -196,7 +196,7 @@ bool CHashTableSession::Bootstrap()
     LogPrint("dht", "DHTTorrentNetwork -- Bootstrap failed after 30 second timeout.\n");
     return false;
 }
-
+/*
 std::string CHashTableSession::GetSessionStatePath()
 {
     boost::filesystem::path path = GetDataDir() / "dht_state.dat";
@@ -247,7 +247,7 @@ bool CHashTableSession::LoadSessionState()
     }
     return true;
 }
-
+*/
 void static StartDHTNetwork(const CChainParams& chainparams, CConnman& connman)
 {
     LogPrintf("%s -- starting\n", __func__);
@@ -434,22 +434,13 @@ bool CHashTableSession::SubmitPut(const std::array<char, 32> public_key, const s
 
 bool CHashTableSession::SubmitGet(const std::array<char, 32>& public_key, const std::string& recordSalt)
 {
-    LogPrintf("CHashTableSession::%s -- Start.\n", __func__);
-    //TODO: DHT add locks
     if (!Session) {
-        //message = "DHTTorrentNetwork -- GetDHTMutableData Error. Session is null.";
+        LogPrintf("CHashTableSession::%s -- Session null.  Submit get failed.\n", __func__);
         return false;
     }
     if (!Session->is_dht_running()) {
-        LogPrintf("CHashTableSession::%s -- GetDHTMutableData Restarting DHT.\n", __func__);
-        if (!LoadSessionState()) {
-            LogPrintf("DHTTorrentNetwork -- GetDHTMutableData Couldn't load previous settings.  Trying to Bootstrap again.\n");
-            if (!Bootstrap())
-                return false;
-        }
-        else {
-            LogPrintf("CHashTableSession::%s -- GetDHTMutableData  setting loaded from file.\n", __func__);
-        }
+        LogPrintf("CHashTableSession::%s -- Session not running.  Submit get failed.\n", __func__);
+        return false;
     }
     Session->dht_get_item(public_key, recordSalt);
     LogPrint("dht", "CHashTableSession::%s -- pubkey = %s, salt = %s\n", __func__, aux::to_hex(public_key), recordSalt);

--- a/src/dht/session.cpp
+++ b/src/dht/session.cpp
@@ -422,7 +422,6 @@ bool CHashTableSession::SubmitPut(const std::array<char, 32> public_key, const s
 
 bool CHashTableSession::SubmitGet(const std::array<char, 32>& public_key, const std::string& recordSalt)
 {
-    LogPrintf("CHashTableSession::%s -- Start.\n", __func__);
     //TODO: DHT add locks
     if (!Session) {
         //message = "DHTTorrentNetwork -- GetDHTMutableData Error. Session is null.";
@@ -800,7 +799,8 @@ bool SubmitPut(const std::array<char, 32> public_key, const std::array<char, 64>
         }
         arraySessions[nCounter].second->SubmitPut(public_key, private_key, lastSequence, pair.first, pair.second);
         LogPrintf("%s -- salt: %s, value: %s\n", __func__, pair.first, pair.second.to_string());
-        nCounter++;
+        if (fMultiThreads)
+            nCounter++;
     }
     nPutRecords++;
 

--- a/src/dht/session.cpp
+++ b/src/dht/session.cpp
@@ -38,11 +38,12 @@ using namespace libtorrent;
 
 static std::shared_ptr<std::thread> pDHTTorrentThread;
 static std::shared_ptr<std::thread> pThreadGet;
+static std::shared_ptr<std::thread> pThreadPut;
 static bool fShutdown;
 static bool fStarted;
 
-CHashTableSession* pHashTableSession;
-//CHashTableSession* pHashTableSessionPut;
+CHashTableSession* pHashTableSessionGet;
+CHashTableSession* pHashTableSessionPut;
 
 namespace DHT {
 
@@ -102,13 +103,17 @@ void StopEventListener()
 
 void StartEventListener(CHashTableSession* dhtSession)
 {
-    LogPrintf("%s -- Starting.\n", __func__);
+    if (!dhtSession) {
+        LogPrintf("%s -- session pointer is null.  Can not listen to events.\n", __func__);
+        return;
+    }
+    LogPrintf("%s -- Starting %s session.\n", __func__, dhtSession->strName);
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
-    RenameThread("dht-events");
+    std::string strThreadName = "dht-events:" + dhtSession->strName;
+    RenameThread(strThreadName.c_str());
     unsigned int counter = 0;
     while(!fShutdown)
     {
-        LogPrintf("%s -- 3\n", __func__);
         if (!dhtSession->Session->is_dht_running()) {
             LogPrint("dht", "%s -- DHT is not running yet\n", __func__);
             MilliSleep(2000);
@@ -260,18 +265,21 @@ void static StartDHTNetwork(const CChainParams& chainparams, CConnman& connman)
 
         fStarted = true;
         // with current peers and Dynodes
+        pHashTableSessionGet->strName = "get1";
         settingsGet.LoadSettings();
-        pHashTableSession->Session = settingsGet.GetSession();
-        if (!pHashTableSession->Session)
+        pHashTableSessionGet->Session = settingsGet.GetSession();
+        if (!pHashTableSessionGet->Session)
             throw std::runtime_error("DHT Torrent network bootstraping error.");
 
+        pThreadGet = std::make_shared<std::thread>(std::bind(&StartEventListener, std::ref(pHashTableSessionGet)));
+
+        pHashTableSessionPut->strName = "put1";
         settingsPut.LoadSettings();
-        //pHashTableSessionPut->Session = settingsPut.GetSession();
-        //if (!pHashTableSessionPut->Session)
-        //    throw std::runtime_error("DHT Torrent network bootstraping error.");
-        pThreadGet = std::make_shared<std::thread>(std::bind(&StartEventListener, std::ref(pHashTableSession)));
-        //std::shared_ptr<std::thread> pThreadPut;
-        //pThreadPut = std::make_shared<std::thread>(std::bind(&StartEventListener, std::ref(pHashTableSessionPut)));
+        pHashTableSessionPut->Session = settingsPut.GetSession();
+        if (!pHashTableSessionPut->Session)
+            throw std::runtime_error("DHT Torrent network bootstraping error.");
+
+        pThreadPut = std::make_shared<std::thread>(std::bind(&StartEventListener, std::ref(pHashTableSessionPut)));
     }
     catch (const std::runtime_error& e)
     {
@@ -300,11 +308,14 @@ void StopTorrentDHTNetwork()
             libtorrent::session_params params;
             params.settings.set_bool(settings_pack::enable_dht, false);
             params.settings.set_int(settings_pack::alert_mask, 0x0);
-            pHashTableSession->Session->apply_settings(params.settings);
-            pHashTableSession->Session->abort();
+            pHashTableSessionGet->Session->apply_settings(params.settings);
+            pHashTableSessionGet->Session->abort();
+            pHashTableSessionPut->Session->apply_settings(params.settings);
+            pHashTableSessionPut->Session->abort();
         }
         pDHTTorrentThread->join();
         pThreadGet->join();
+        pThreadPut->join();
         LogPrint("dht", "DHTTorrentNetwork -- StopTorrentDHTNetwork abort.\n");
     }
     else {

--- a/src/dht/session.cpp
+++ b/src/dht/session.cpp
@@ -37,11 +37,12 @@
 using namespace libtorrent;
 
 static std::shared_ptr<std::thread> pDHTTorrentThread;
-
+static std::shared_ptr<std::thread> pThreadGet;
 static bool fShutdown;
 static bool fStarted;
 
 CHashTableSession* pHashTableSession;
+//CHashTableSession* pHashTableSessionPut;
 
 namespace DHT {
 
@@ -92,7 +93,79 @@ namespace DHT {
     }
 }
 
-bool Bootstrap()
+void StopEventListener()
+{
+    fShutdown = true;
+    LogPrintf("%s -- stopping.\n", __func__);
+    MilliSleep(2100);
+}
+
+void StartEventListener(CHashTableSession* dhtSession)
+{
+    LogPrintf("%s -- Starting.\n", __func__);
+    SetThreadPriority(THREAD_PRIORITY_LOWEST);
+    RenameThread("dht-events");
+    unsigned int counter = 0;
+    while(!fShutdown)
+    {
+        LogPrintf("%s -- 3\n", __func__);
+        if (!dhtSession->Session->is_dht_running()) {
+            LogPrint("dht", "%s -- DHT is not running yet\n", __func__);
+            MilliSleep(2000);
+            continue;
+        }
+
+        dhtSession->Session->wait_for_alert(seconds(1));
+        std::vector<alert*> alerts;
+        dhtSession->Session->pop_alerts(&alerts);
+        for (std::vector<alert*>::iterator iAlert = alerts.begin(), end(alerts.end()); iAlert != end; ++iAlert) {
+            if ((*iAlert) == nullptr)
+                continue;
+
+            const uint32_t iAlertCategory = (*iAlert)->category();
+            const std::string strAlertMessage = (*iAlert)->message();
+            const int iAlertType = (*iAlert)->type();
+            const std::string strAlertTypeName = alert_name(iAlertType);
+            if (iAlertType == DHT_GET_ALERT_TYPE_CODE || iAlertType == DHT_PUT_ALERT_TYPE_CODE) {
+                if (iAlertType == DHT_GET_ALERT_TYPE_CODE) {
+                    // DHT Get Mutable Event
+                    dht_mutable_item_alert* pGet = alert_cast<dht_mutable_item_alert>((*iAlert));
+                    if (pGet == nullptr)
+                        continue;
+                    LogPrint("dht", "%s -- PubKey = %s, Salt = %s, Value = %s\nMessage = %s, Alert Type =%s, Alert Category = %u\n"
+                        , __func__, aux::to_hex(pGet->key), pGet->salt, pGet->item.to_string(), strAlertMessage, strAlertTypeName, iAlertCategory);
+
+                    if (pGet->item.to_string() != "<uninitialized>") {
+                        const CMutableGetEvent event(strAlertMessage, iAlertType, iAlertCategory, strAlertTypeName, 
+                          aux::to_hex(pGet->key), pGet->salt, pGet->seq, pGet->item.to_string(), aux::to_hex(pGet->signature), pGet->authoritative);
+
+                        std::string infoHash = GetInfoHash(event.PublicKey(), event.Salt());
+                        dhtSession->AddToDHTGetEventMap(infoHash, event);
+                    }
+                }
+            }
+            else if (iAlertType == DHT_STATS_ALERT_TYPE_CODE) {
+                // TODO (dht): handle stats 
+                //dht_stats_alert* pAlert = alert_cast<dht_stats_alert>((*iAlert));
+                LogPrintf("%s -- DHT Alert Message: AlertType = %s\n", __func__, strAlertTypeName); 
+            }
+            else {
+                const CEvent event(strAlertMessage, iAlertType, iAlertCategory, strAlertTypeName);
+                dhtSession->AddToEventMap(iAlertType, event);
+            }
+        }
+        if (fShutdown)
+            return;
+        
+        counter++;
+        if (counter % 60 == 0) {
+            LogPrint("dht", "DHTEventListener -- Before CleanUpEventMap. counter = %u\n", counter);
+            dhtSession->CleanUpEventMap(300000);
+        }
+    }
+}
+
+bool CHashTableSession::Bootstrap()
 {
     LogPrintf("dht", "DHTTorrentNetwork -- bootstrapping.\n");
     const int64_t timeout = 30000; // 30 seconds
@@ -113,16 +186,16 @@ bool Bootstrap()
     return false;
 }
 
-std::string GetSessionStatePath()
+std::string CHashTableSession::GetSessionStatePath()
 {
     boost::filesystem::path path = GetDataDir() / "dht_state.dat";
     return path.string();
 }
 
-int SaveSessionState(session* dhtSession)
+int CHashTableSession::SaveSessionState()
 {
     entry torrentEntry;
-    dhtSession->save_state(torrentEntry, session::save_dht_state);
+    Session->save_state(torrentEntry, session::save_dht_state);
     std::vector<char> state;
     bencode(std::back_inserter(state), torrentEntry);
     std::fstream f(GetSessionStatePath().c_str(), std::ios_base::out | std::ios_base::binary | std::ios_base::trunc);
@@ -131,7 +204,7 @@ int SaveSessionState(session* dhtSession)
     return 0;
 }
 
-bool LoadSessionState(session* dhtSession)
+bool CHashTableSession::LoadSessionState()
 {
     std::fstream f(GetSessionStatePath().c_str(), std::ios_base::in | std::ios_base::binary | std::ios_base::ate);
 
@@ -159,19 +232,17 @@ bool LoadSessionState(session* dhtSession)
     else
     {
         LogPrint("dht", "DHTTorrentNetwork -- LoadSessionState load dht state from dht-state.log\n");
-        dhtSession->load_state(e);
+        Session->load_state(e);
     }
     return true;
 }
 
-void static DHTTorrentNetwork(const CChainParams& chainparams, CConnman& connman)
+void static StartDHTNetwork(const CChainParams& chainparams, CConnman& connman)
 {
-    LogPrint("dht", "DHTTorrentNetwork -- starting\n");
+    LogPrintf("%s -- starting\n", __func__);
     SetThreadPriority(THREAD_PRIORITY_LOWEST);
     RenameThread("dht-session");
-    
     try {
-        CDHTSettings settings;
         // Busy-wait for the network to come online so we get a full list of Dynodes
         do {
             bool fvNodesEmpty = connman.GetNodeCount(CConnman::CONNECTIONS_ALL) == 0;
@@ -184,17 +255,23 @@ void static DHTTorrentNetwork(const CChainParams& chainparams, CConnman& connman
                 return;
 
         } while (true);
-        
+        CDHTSettings settingsGet(1);
+        CDHTSettings settingsPut(2);
+
         fStarted = true;
-        LogPrintf("DHTTorrentNetwork -- started\n");
         // with current peers and Dynodes
-        settings.LoadSettings();
-        pHashTableSession->Session = settings.GetSession();
-        
+        settingsGet.LoadSettings();
+        pHashTableSession->Session = settingsGet.GetSession();
         if (!pHashTableSession->Session)
             throw std::runtime_error("DHT Torrent network bootstraping error.");
-        
-        StartEventListener(pHashTableSession->Session);
+
+        settingsPut.LoadSettings();
+        //pHashTableSessionPut->Session = settingsPut.GetSession();
+        //if (!pHashTableSessionPut->Session)
+        //    throw std::runtime_error("DHT Torrent network bootstraping error.");
+        pThreadGet = std::make_shared<std::thread>(std::bind(&StartEventListener, std::ref(pHashTableSession)));
+        //std::shared_ptr<std::thread> pThreadPut;
+        //pThreadPut = std::make_shared<std::thread>(std::bind(&StartEventListener, std::ref(pHashTableSessionPut)));
     }
     catch (const std::runtime_error& e)
     {
@@ -202,6 +279,11 @@ void static DHTTorrentNetwork(const CChainParams& chainparams, CConnman& connman
         LogPrintf("DHTTorrentNetwork -- runtime error: %s\n", e.what());
         return;
     }
+}
+
+void StartTorrentDHTNetwork(const CChainParams& chainparams, CConnman& connman)
+{
+    pDHTTorrentThread = std::make_shared<std::thread>(std::bind(&StartDHTNetwork, std::cref(chainparams), std::ref(connman)));
 }
 
 void StopTorrentDHTNetwork()
@@ -222,6 +304,7 @@ void StopTorrentDHTNetwork()
             pHashTableSession->Session->abort();
         }
         pDHTTorrentThread->join();
+        pThreadGet->join();
         LogPrint("dht", "DHTTorrentNetwork -- StopTorrentDHTNetwork abort.\n");
     }
     else {
@@ -231,29 +314,18 @@ void StopTorrentDHTNetwork()
     LogPrintf("DHTTorrentNetwork -- Stopped.\n");
 }
 
-void StartTorrentDHTNetwork(const CChainParams& chainparams, CConnman& connman)
-{
-    LogPrint("dht", "DHTTorrentNetwork -- Log file = %s.\n", GetSessionStatePath());
-    fShutdown = false;
-    fStarted = false;
-    if (pDHTTorrentThread != NULL)
-         StopTorrentDHTNetwork();
-
-    pDHTTorrentThread = std::make_shared<std::thread>(std::bind(&DHTTorrentNetwork, std::cref(chainparams), std::ref(connman)));
-}
-
-void GetDHTStats(session_status& stats, std::vector<dht_lookup>& vchDHTLookup, std::vector<dht_routing_bucket>& vchDHTBuckets)
+void CHashTableSession::GetDHTStats(session_status& stats, std::vector<dht_lookup>& vchDHTLookup, std::vector<dht_routing_bucket>& vchDHTBuckets)
 {
     LogPrint("dht", "DHTTorrentNetwork -- GetDHTStats started.\n");
 
-    if (!pHashTableSession->Session) {
+    if (!Session) {
         return;
     }
 
-    if (!pHashTableSession->Session->is_dht_running()) {
+    if (!Session->is_dht_running()) {
         return;
         //LogPrint("dht", "DHTTorrentNetwork -- GetDHTStats Restarting DHT.\n");
-        //if (!LoadSessionState(pHashTableSession->Session)) {
+        //if (!LoadSessionState(Session)) {
         //    LogPrint("dht", "DHTTorrentNetwork -- GetDHTStats Couldn't load previous settings.  Trying to bootstrap again.\n");
         //    Bootstrap();
         //}
@@ -265,13 +337,13 @@ void GetDHTStats(session_status& stats, std::vector<dht_lookup>& vchDHTLookup, s
         LogPrint("dht", "DHTTorrentNetwork -- GetDHTStats DHT already running.  Bootstrap not needed.\n");
     }
 
-    pHashTableSession->Session->post_dht_stats();
+    Session->post_dht_stats();
     //get alert from map
-    //alert* dhtAlert = WaitForResponse(pHashTableSession->Session, dht_stats_alert::alert_type);
+    //alert* dhtAlert = WaitForResponse(Session, dht_stats_alert::alert_type);
     //dht_stats_alert* dhtStatsAlert = alert_cast<dht_stats_alert>(dhtAlert);
     //vchDHTLookup = dhtStatsAlert->active_requests;
     //vchDHTBuckets = dhtStatsAlert->routing_table;
-    stats = pHashTableSession->Session->status();
+    stats = Session->status();
 }
 
 void CHashTableSession::CleanUpPutCommandMap()
@@ -352,7 +424,7 @@ bool CHashTableSession::SubmitGet(const std::array<char, 32>& public_key, const 
 
     if (!Session->is_dht_running()) {
         LogPrintf("CHashTableSession::%s -- GetDHTMutableData Restarting DHT.\n", __func__);
-        if (!LoadSessionState(Session)) {
+        if (!LoadSessionState()) {
             LogPrintf("DHTTorrentNetwork -- GetDHTMutableData Couldn't load previous settings.  Trying to Bootstrap again.\n");
             if (!Bootstrap())
                 return false;
@@ -586,6 +658,90 @@ bool CHashTableSession::SubmitGetAllRecordsAsync(const std::vector<CLinkInfo>& v
                 }
             }
         }
+    }
+    return true;
+}
+
+void CHashTableSession::AddToDHTGetEventMap(const std::string& infoHash, const CMutableGetEvent& event)
+{
+    LOCK(cs_DHTGetEventMap);
+    if (m_DHTGetEventMap.find(infoHash) == m_DHTGetEventMap.end()) {
+        // event not found. Add a new entry to DHT event map
+        LogPrint("dht", "AddToDHTGetEventMap Not found -- infohash = %s\n", infoHash);
+        m_DHTGetEventMap.insert(std::make_pair(infoHash, event));
+    }
+    else {
+        // event found. Update entry in DHT event map
+        LogPrint("dht", "AddToDHTGetEventMap Found -- Updateinfohash = %s\n", infoHash);
+        m_DHTGetEventMap[infoHash] = event;
+    }
+}
+
+void CHashTableSession::AddToEventMap(const int type, const CEvent& event)
+{
+    LOCK(cs_EventMap);
+    m_EventTypeMap.insert(std::make_pair(type, std::make_pair(event.Timestamp(), event)));
+}
+
+void CHashTableSession::CleanUpEventMap(const uint32_t timeout)
+{
+    unsigned int deleted = 0;
+    unsigned int counter = 0;
+    int64_t iTime = GetTimeMillis();
+    LOCK(cs_EventMap);
+    for (auto it = m_EventTypeMap.begin(); it != m_EventTypeMap.end(); ) {
+        CEvent event = it->second.second;
+        if ((iTime - event.Timestamp()) > timeout) {
+            it = m_EventTypeMap.erase(it);
+            deleted++;
+        }
+        else {
+            ++it;
+        }
+        counter++;
+    }
+    LogPrint("dht", "DHTEventListener -- CleanUpEventMap. deleted = %u, count = %u\n", deleted, counter);
+}
+
+bool CHashTableSession::GetLastTypeEvent(const int& type, const int64_t& startTime, std::vector<CEvent>& events)
+{
+    //LOCK(cs_EventMap);
+    LogPrint("dht", "GetLastTypeEvent -- m_EventTypeMap.size = %u, type = %u.\n", m_EventTypeMap.size(), type);
+    std::multimap<int, EventPair>::iterator iEvents = m_EventTypeMap.find(type);
+    while (iEvents != m_EventTypeMap.end()) {
+        if (iEvents->second.first >= startTime) {
+            events.push_back(iEvents->second.second);
+        }
+        iEvents++;
+    }
+    LogPrint("dht", "GetLastTypeEvent -- events.size() = %u\n", events.size());
+    return events.size() > 0;
+}
+
+bool CHashTableSession::FindDHTGetEvent(const std::string& infoHash, CMutableGetEvent& event)
+{
+    //LOCK(cs_DHTGetEventMap);
+    std::map<std::string, CMutableGetEvent>::iterator iMutableEvent = m_DHTGetEventMap.find(infoHash);
+    if (iMutableEvent != m_DHTGetEventMap.end()) {
+        // event found.
+        event = iMutableEvent->second;
+        return true;
+    }
+    return false;
+}
+
+bool CHashTableSession::RemoveDHTGetEvent(const std::string& infoHash)
+{
+    LOCK(cs_DHTGetEventMap);
+    m_DHTGetEventMap.erase(infoHash);
+    return true;
+}
+
+bool CHashTableSession::GetAllDHTGetEvents(std::vector<CMutableGetEvent>& vchGetEvents)
+{
+    //LOCK(cs_DHTGetEventMap);
+    for (std::map<std::string, CMutableGetEvent>::iterator it=m_DHTGetEventMap.begin(); it!=m_DHTGetEventMap.end(); ++it) {
+        vchGetEvents.push_back(it->second);
     }
     return true;
 }

--- a/src/dht/session.cpp
+++ b/src/dht/session.cpp
@@ -502,6 +502,9 @@ bool CHashTableSession::SubmitGetRecord(const std::array<char, 32>& public_key, 
             i++;
         }
     }
+    if (strHeaderHex == "")
+        return false; // Header failed, so don't try to get the rest of the record.
+
     header.LoadHex(strHeaderHex);
     if (!header.IsNull() && header.nChunks > 0) {
         std::vector<CDataChunk> vChunks;

--- a/src/dht/session.cpp
+++ b/src/dht/session.cpp
@@ -6,8 +6,8 @@
 
 #include "bdap/linkstorage.h"
 #include "bdap/utils.h"
-#include "dht/sessionevents.h"
 #include "chainparams.h"
+#include "dht/sessionevents.h"
 #include "dht/datachunk.h"
 #include "dht/dataheader.h"
 #include "dht/settings.h"

--- a/src/dht/session.cpp
+++ b/src/dht/session.cpp
@@ -36,14 +36,17 @@
 
 using namespace libtorrent;
 
-static std::shared_ptr<std::thread> pDHTTorrentThread;
-static std::shared_ptr<std::thread> pThreadGet;
-static std::shared_ptr<std::thread> pThreadPut;
-static bool fShutdown;
-static bool fStarted;
+static constexpr size_t nThreads = 17;
 
-CHashTableSession* pHashTableSessionGet;
-CHashTableSession* pHashTableSessionPut;
+typedef std::array<std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>>, nThreads> SessionThreadGroup;
+
+static SessionThreadGroup arrayGetSessionThreads;
+static SessionThreadGroup arrayPutSessionThreads;
+
+static std::shared_ptr<std::thread> pDHTTorrentThread;
+
+static bool fStarted;
+static bool fRun;
 
 namespace DHT {
 
@@ -94,14 +97,14 @@ namespace DHT {
     }
 }
 
-void StopEventListener()
+void CHashTableSession::StopEventListener()
 {
     fShutdown = true;
     LogPrintf("%s -- stopping.\n", __func__);
-    MilliSleep(2100);
+    MilliSleep(30);
 }
 
-void StartEventListener(CHashTableSession* dhtSession)
+void StartEventListener(std::shared_ptr<CHashTableSession> dhtSession)
 {
     if (!dhtSession) {
         LogPrintf("%s -- session pointer is null.  Can not listen to events.\n", __func__);
@@ -112,7 +115,7 @@ void StartEventListener(CHashTableSession* dhtSession)
     std::string strThreadName = "dht-events:" + dhtSession->strName;
     RenameThread(strThreadName.c_str());
     unsigned int counter = 0;
-    while(!fShutdown)
+    while(!dhtSession->fShutdown)
     {
         if (!dhtSession->Session->is_dht_running()) {
             LogPrint("dht", "%s -- DHT is not running yet\n", __func__);
@@ -159,9 +162,9 @@ void StartEventListener(CHashTableSession* dhtSession)
                 dhtSession->AddToEventMap(iAlertType, event);
             }
         }
-        if (fShutdown)
+        if (dhtSession->fShutdown)
             return;
-        
+
         counter++;
         if (counter % 60 == 0) {
             LogPrint("dht", "DHTEventListener -- Before CleanUpEventMap. counter = %u\n", counter);
@@ -256,34 +259,37 @@ void static StartDHTNetwork(const CChainParams& chainparams, CConnman& connman)
                     break;
 
             MilliSleep(1000);
-            if (fShutdown)
+            if (!fRun)
                 return;
 
         } while (true);
-        CDHTSettings settingsGet(1);
-        CDHTSettings settingsPut(2);
-
+        // start all DHT Get sessions
+        for (unsigned int i = 0; i < nThreads; i++) {
+            std::shared_ptr<CHashTableSession> pDHTSession(new CHashTableSession());
+            CDHTSettings settings(i);
+            pDHTSession->strName = strprintf("get%d", std::to_string(i));
+            settings.LoadSettings();
+            pDHTSession->Session = settings.GetSession();
+            std::shared_ptr<std::thread> pSessionThread = std::make_shared<std::thread>(std::bind(&StartEventListener, std::ref(pDHTSession)));
+            arrayGetSessionThreads[i] = std::make_pair(pSessionThread, pDHTSession);
+            MilliSleep(30);
+        }
+        // start all DHT Put sessions
+        for (unsigned int i = 0; i < nThreads; i++) {
+            std::shared_ptr<CHashTableSession> pDHTSession(new CHashTableSession());
+            CDHTSettings settings(i + nThreads);
+            pDHTSession->strName = strprintf("put%d", std::to_string(i));
+            settings.LoadSettings();
+            pDHTSession->Session = settings.GetSession();
+            std::shared_ptr<std::thread> pSessionThread = std::make_shared<std::thread>(std::bind(&StartEventListener, std::ref(pDHTSession)));
+            arrayPutSessionThreads[i] = std::make_pair(pSessionThread, pDHTSession);
+            MilliSleep(30);
+        }
         fStarted = true;
-        // with current peers and Dynodes
-        pHashTableSessionGet->strName = "get1";
-        settingsGet.LoadSettings();
-        pHashTableSessionGet->Session = settingsGet.GetSession();
-        if (!pHashTableSessionGet->Session)
-            throw std::runtime_error("DHT Torrent network bootstraping error.");
-
-        pThreadGet = std::make_shared<std::thread>(std::bind(&StartEventListener, std::ref(pHashTableSessionGet)));
-
-        pHashTableSessionPut->strName = "put1";
-        settingsPut.LoadSettings();
-        pHashTableSessionPut->Session = settingsPut.GetSession();
-        if (!pHashTableSessionPut->Session)
-            throw std::runtime_error("DHT Torrent network bootstraping error.");
-
-        pThreadPut = std::make_shared<std::thread>(std::bind(&StartEventListener, std::ref(pHashTableSessionPut)));
     }
     catch (const std::runtime_error& e)
     {
-        fShutdown = true;
+        fRun = false;
         LogPrintf("DHTTorrentNetwork -- runtime error: %s\n", e.what());
         return;
     }
@@ -291,38 +297,57 @@ void static StartDHTNetwork(const CChainParams& chainparams, CConnman& connman)
 
 void StartTorrentDHTNetwork(const CChainParams& chainparams, CConnman& connman)
 {
+    fRun = true;
+    fStarted = false;
+    if (pDHTTorrentThread != NULL)
+         StopTorrentDHTNetwork();
+
     pDHTTorrentThread = std::make_shared<std::thread>(std::bind(&StartDHTNetwork, std::cref(chainparams), std::ref(connman)));
 }
 
 void StopTorrentDHTNetwork()
 {
-    LogPrintf("DHTTorrentNetwork -- StopTorrentDHTNetwork begin.\n");
-    fShutdown = true;
-    MilliSleep(300);
-    StopEventListener();
-    MilliSleep(30);
+    LogPrintf("%s --Begin stopping all DHT session threads.\n", __func__);
+    fRun = false;
     if (pDHTTorrentThread != NULL)
     {
         LogPrint("dht", "DHTTorrentNetwork -- StopTorrentDHTNetwork trying to stop.\n");
-        if (fStarted) { 
+        if (fStarted) {
             libtorrent::session_params params;
             params.settings.set_bool(settings_pack::enable_dht, false);
             params.settings.set_int(settings_pack::alert_mask, 0x0);
-            pHashTableSessionGet->Session->apply_settings(params.settings);
-            pHashTableSessionGet->Session->abort();
-            pHashTableSessionPut->Session->apply_settings(params.settings);
-            pHashTableSessionPut->Session->abort();
+            // stop all DHT Get sessions
+            for (unsigned int i = 0; i < nThreads; i++) {
+                std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayGetSessionThreads[i];
+                pairSession.second->StopEventListener();
+                MilliSleep(30);
+                pairSession.second->Session->apply_settings(params.settings);
+                pairSession.second->Session->abort();
+            }
+            // stop all DHT Put sessions
+            for (unsigned int i = 0; i < nThreads; i++) {
+                std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayPutSessionThreads[i];
+                pairSession.second->StopEventListener();
+                MilliSleep(30);
+                pairSession.second->Session->apply_settings(params.settings);
+                pairSession.second->Session->abort();
+            }
+
         }
         pDHTTorrentThread->join();
-        pThreadGet->join();
-        pThreadPut->join();
-        LogPrint("dht", "DHTTorrentNetwork -- StopTorrentDHTNetwork abort.\n");
-    }
-    else {
-        LogPrint("dht", "DHTTorrentNetwork --StopTorrentDHTNetwork pDHTTorrentThreads is null.  Stop not needed.\n");
+        // join all DHT Get threads
+        for (unsigned int i = 0; i < nThreads; i++) {
+            std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayGetSessionThreads[i];
+            pairSession.first->join();
+        }
+        // join all DHT Put threads
+        for (unsigned int i = 0; i < nThreads; i++) {
+            std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayPutSessionThreads[i];
+            pairSession.first->join();
+        }
     }
     pDHTTorrentThread = NULL;
-    LogPrintf("DHTTorrentNetwork -- Stopped.\n");
+    LogPrintf("%s --Finished stopping all DHT session threads.\n", __func__);
 }
 
 void CHashTableSession::GetDHTStats(session_status& stats, std::vector<dht_lookup>& vchDHTLookup, std::vector<dht_routing_bucket>& vchDHTBuckets)
@@ -756,3 +781,130 @@ bool CHashTableSession::GetAllDHTGetEvents(std::vector<CMutableGetEvent>& vchGet
     }
     return true;
 }
+
+namespace DHT
+{
+
+bool PutStatus(const size_t nSessionThread)
+{
+    if (nSessionThread >= nThreads)
+        return false;
+
+    std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayPutSessionThreads[nSessionThread];
+    if (!arrayPutSessionThreads[nSessionThread].second)
+        return false;
+
+    return true;
+}
+
+bool GetStatus(const size_t nSessionThread)
+{
+    if (nSessionThread >= nThreads)
+        return false;
+
+    std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayGetSessionThreads[nSessionThread];
+    if (!arrayGetSessionThreads[nSessionThread].second)
+        return false;
+
+    return true;
+}
+
+bool SubmitPut(const size_t nSessionThread, const std::array<char, 32> public_key, const std::array<char, 64> private_key, const int64_t lastSequence, CDataRecord record)
+{
+    if (nSessionThread >= nThreads)
+        return false;
+
+    std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayPutSessionThreads[nSessionThread];
+    if (!arrayPutSessionThreads[nSessionThread].second)
+        return false;
+
+    return arrayPutSessionThreads[nSessionThread].second->SubmitPut(public_key, private_key, lastSequence, record);
+}
+
+bool SubmitGet(const size_t nSessionThread, const std::array<char, 32>& public_key, const std::string& recordSalt)
+{
+    if (nSessionThread >= nThreads)
+        return false;
+
+    std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayGetSessionThreads[nSessionThread];
+    if (!arrayGetSessionThreads[nSessionThread].second)
+        return false;
+
+    return arrayGetSessionThreads[nSessionThread].second->SubmitGet(public_key, recordSalt);
+}
+
+bool SubmitGet(const size_t nSessionThread, const std::array<char, 32>& public_key, const std::string& recordSalt, const int64_t& timeout, 
+                            std::string& recordValue, int64_t& lastSequence, bool& fAuthoritative)
+{
+    if (nSessionThread >= nThreads)
+        return false;
+
+    std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayGetSessionThreads[nSessionThread];
+    if (!arrayGetSessionThreads[nSessionThread].second)
+        return false;
+
+    return arrayGetSessionThreads[nSessionThread].second->SubmitGet(public_key, recordSalt, timeout, recordValue, lastSequence, fAuthoritative);
+}
+
+bool SubmitGetRecord(const size_t nSessionThread, const std::array<char, 32>& public_key, const std::array<char, 32>& private_seed, 
+                        const std::string& strOperationType, int64_t& iSequence, CDataRecord& record)
+{
+    if (nSessionThread >= nThreads)
+        return false;
+
+    std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayGetSessionThreads[nSessionThread];
+    if (!arrayGetSessionThreads[nSessionThread].second)
+        return false;
+
+    return arrayGetSessionThreads[nSessionThread].second->SubmitGetRecord(public_key, private_seed, strOperationType, iSequence, record);
+}
+
+bool SubmitGetAllRecordsSync(const size_t nSessionThread, const std::vector<CLinkInfo>& vchLinkInfo, const std::string& strOperationType, std::vector<CDataRecord>& vchRecords)
+{
+    if (nSessionThread >= nThreads)
+        return false;
+
+    std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayGetSessionThreads[nSessionThread];
+    if (!arrayGetSessionThreads[nSessionThread].second)
+        return false;
+
+    return arrayGetSessionThreads[nSessionThread].second->SubmitGetAllRecordsSync(vchLinkInfo, strOperationType, vchRecords);
+}
+
+bool SubmitGetAllRecordsAsync(const size_t nSessionThread, const std::vector<CLinkInfo>& vchLinkInfo, const std::string& strOperationType, std::vector<CDataRecord>& vchRecords)
+{
+    if (nSessionThread >= nThreads)
+        return false;
+
+    std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayGetSessionThreads[nSessionThread];
+    if (!arrayGetSessionThreads[nSessionThread].second)
+        return false;
+
+    return arrayGetSessionThreads[nSessionThread].second->SubmitGetAllRecordsAsync(vchLinkInfo, strOperationType, vchRecords);
+}
+
+bool GetAllDHTGetEvents(const size_t nSessionThread, std::vector<CMutableGetEvent>& vchGetEvents)
+{
+    if (nSessionThread >= nThreads)
+        return false;
+
+    std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayGetSessionThreads[nSessionThread];
+    if (!arrayGetSessionThreads[nSessionThread].second)
+        return false;
+
+    return arrayGetSessionThreads[nSessionThread].second->GetAllDHTGetEvents(vchGetEvents);
+}
+
+void GetDHTStats(const size_t nSessionThread, libtorrent::session_status& stats, std::vector<libtorrent::dht_lookup>& vchDHTLookup, std::vector<libtorrent::dht_routing_bucket>& vchDHTBuckets)
+{
+    if (nSessionThread >= nThreads)
+        return;
+
+    std::pair<std::shared_ptr<std::thread>, std::shared_ptr<CHashTableSession>> pairSession = arrayGetSessionThreads[nSessionThread];
+    if (!arrayGetSessionThreads[nSessionThread].second)
+        return;
+
+    arrayGetSessionThreads[nSessionThread].second->GetDHTStats(stats, vchDHTLookup, vchDHTBuckets);
+}
+
+} // end DHT namespace

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -85,15 +85,14 @@ uint32_t GetLastPutDate(const HashRecordKey& recordKey);
 void CleanUpPutCommandMap();
 
 /** Start the DHT libtorrent network threads */
-void StartTorrentDHTNetwork(const CChainParams& chainparams, CConnman& connman);
+void StartTorrentDHTNetwork(const bool multithreads, const CChainParams& chainparams, CConnman& connman);
 /** Stop the DHT libtorrent network threads */
 void StopTorrentDHTNetwork();
 void StartEventListener(std::shared_ptr<CHashTableSession> dhtSession);
 
 namespace DHT
 {
-    bool PutStatus(const size_t nSessionThread);
-    bool GetStatus(const size_t nSessionThread);
+    bool SessionStatus();
     bool SubmitPut(const std::array<char, 32> public_key, const std::array<char, 64> private_key, const int64_t lastSequence, const CDataRecord& record, std::string& strErrorMessage);
     bool SubmitGet(const size_t nSessionThread, const std::array<char, 32>& public_key, const std::string& recordSalt);
     bool SubmitGet(const size_t nSessionThread, const std::array<char, 32>& public_key, const std::string& recordSalt, const int64_t& timeout, 
@@ -105,4 +104,5 @@ namespace DHT
     bool GetAllDHTGetEvents(const size_t nSessionThread, std::vector<CMutableGetEvent>& vchGetEvents);
     void GetDHTStats(const size_t nSessionThread, libtorrent::session_status& stats, std::vector<libtorrent::dht_lookup>& vchDHTLookup, std::vector<libtorrent::dht_routing_bucket>& vchDHTBuckets);
 }
+
 #endif // DYNAMIC_DHT_SESSION_H

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -25,12 +25,6 @@ class CLinkInfo;
 class CMutableData;
 class CMutableGetEvent;
 
-namespace libtorrent {
-    namespace dht {
-        class item;
-    }
-}
-
 typedef std::pair<int64_t, CEvent> EventPair;
 typedef std::multimap<int, EventPair> EventTypeMap;
 typedef std::map<std::string, CMutableGetEvent> DHTGetEventMap;
@@ -114,7 +108,7 @@ void StartTorrentDHTNetwork(const bool multithreads, const CChainParams& chainpa
 void StopTorrentDHTNetwork();
 void StartEventListener(std::shared_ptr<CHashTableSession> dhtSession);
 void ReannounceEntries();
-bool ConvertMutableEntry(const CMutableData& mut_data, libtorrent::dht::item& mut_item);
+bool ConvertMutableEntry(const CMutableData& mut_data, libtorrent::entry& mut_item);
 
 namespace DHT
 {

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -71,9 +71,9 @@ public:
 
 private:
     bool GetDataFromMap(const std::array<char, 32>& public_key, const std::string& recordSalt, CMutableGetEvent& event);
-    bool LoadSessionState();
-    int SaveSessionState();
-    std::string GetSessionStatePath();
+    //bool LoadSessionState();
+    //int SaveSessionState();
+    //std::string GetSessionStatePath();
     bool RemoveDHTGetEvent(const std::string& infoHash);
     bool GetLastTypeEvent(const int& type, const int64_t& startTime, std::vector<CEvent>& events);
     bool FindDHTGetEvent(const std::string& infoHash, CMutableGetEvent& event);

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -43,18 +43,16 @@ public:
     std::string strName;
     CDataRecordBuffer vDataEntries;
     libtorrent::session* Session = NULL;
-    std::map<HashRecordKey, int64_t> mPutCommands;
-    std::string strPutErrorMessage;
-    uint64_t nPutRecords;
+    std::string strErrorMessage;
     bool fShutdown;
     EventTypeMap m_EventTypeMap;
     DHTGetEventMap m_DHTGetEventMap;
     CCriticalSection cs_EventMap;
     CCriticalSection cs_DHTGetEventMap;
 
-    CHashTableSession() : vDataEntries(CDataRecordBuffer(32)), strPutErrorMessage(""), nPutRecords(0) {};
+    CHashTableSession() : vDataEntries(CDataRecordBuffer(32)), strErrorMessage("") {};
 
-    bool SubmitPut(const std::array<char, 32> public_key, const std::array<char, 64> private_key, const int64_t lastSequence, CDataRecord& record);
+    bool SubmitPut(const std::array<char, 32> public_key, const std::array<char, 64> private_key, const int64_t lastSequence, const std::string& strSalt, const libtorrent::entry& entryValue);
 
     bool SubmitGet(const std::array<char, 32>& public_key, const std::string& recordSalt);
     bool SubmitGet(const std::array<char, 32>& public_key, const std::string& recordSalt, const int64_t& timeout, 
@@ -72,8 +70,7 @@ public:
     void StopEventListener();
 
 private:
-    void CleanUpPutCommandMap();
-    int64_t GetLastPutDate(const HashRecordKey& recordKey);
+    
     bool GetDataFromMap(const std::array<char, 32>& public_key, const std::string& recordSalt, CMutableGetEvent& event);
     bool LoadSessionState();
     int SaveSessionState();
@@ -83,6 +80,9 @@ private:
     bool FindDHTGetEvent(const std::string& infoHash, CMutableGetEvent& event);
 
 };
+
+uint32_t GetLastPutDate(const HashRecordKey& recordKey);
+void CleanUpPutCommandMap();
 
 /** Start the DHT libtorrent network threads */
 void StartTorrentDHTNetwork(const CChainParams& chainparams, CConnman& connman);
@@ -94,7 +94,7 @@ namespace DHT
 {
     bool PutStatus(const size_t nSessionThread);
     bool GetStatus(const size_t nSessionThread);
-    bool SubmitPut(const size_t nSessionThread, const std::array<char, 32> public_key, const std::array<char, 64> private_key, const int64_t lastSequence, CDataRecord record);
+    bool SubmitPut(const std::array<char, 32> public_key, const std::array<char, 64> private_key, const int64_t lastSequence, const CDataRecord& record, std::string& strErrorMessage);
     bool SubmitGet(const size_t nSessionThread, const std::array<char, 32>& public_key, const std::string& recordSalt);
     bool SubmitGet(const size_t nSessionThread, const std::array<char, 32>& public_key, const std::string& recordSalt, const int64_t& timeout, 
                             std::string& recordValue, int64_t& lastSequence, bool& fAuthoritative);

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -109,7 +109,7 @@ void StartTorrentDHTNetwork(const bool multithreads, const CChainParams& chainpa
 void StopTorrentDHTNetwork();
 void StartEventListener(std::shared_ptr<CHashTableSession> dhtSession);
 void ReannounceEntries();
-bool ConvertMutableEntry(const CMutableData& mut_data, libtorrent::entry& mut_item);
+bool ConvertMutableEntryValue(const CMutableData& local_mut_data, libtorrent::entry& dht_item);
 
 namespace DHT
 {

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -69,6 +69,7 @@ public:
     void AddToDHTGetEventMap(const std::string& infoHash, const CMutableGetEvent& event);
     void AddToEventMap(const int type, const CEvent& event);
     void CleanUpEventMap(const uint32_t timeout);
+    void StopEventListener();
 
 private:
     void CleanUpPutCommandMap();
@@ -78,7 +79,6 @@ private:
     int SaveSessionState();
     std::string GetSessionStatePath();
     bool RemoveDHTGetEvent(const std::string& infoHash);
-    void StopEventListener();
     bool GetLastTypeEvent(const int& type, const int64_t& startTime, std::vector<CEvent>& events);
     bool FindDHTGetEvent(const std::string& infoHash, CMutableGetEvent& event);
 
@@ -88,10 +88,21 @@ private:
 void StartTorrentDHTNetwork(const CChainParams& chainparams, CConnman& connman);
 /** Stop the DHT libtorrent network threads */
 void StopTorrentDHTNetwork();
-void StartEventListener(CHashTableSession* dhtSession);
-void StopEventListener();
+void StartEventListener(std::shared_ptr<CHashTableSession> dhtSession);
 
-extern CHashTableSession* pHashTableSessionGet;
-extern CHashTableSession* pHashTableSessionPut;
-
+namespace DHT
+{
+    bool PutStatus(const size_t nSessionThread);
+    bool GetStatus(const size_t nSessionThread);
+    bool SubmitPut(const size_t nSessionThread, const std::array<char, 32> public_key, const std::array<char, 64> private_key, const int64_t lastSequence, CDataRecord record);
+    bool SubmitGet(const size_t nSessionThread, const std::array<char, 32>& public_key, const std::string& recordSalt);
+    bool SubmitGet(const size_t nSessionThread, const std::array<char, 32>& public_key, const std::string& recordSalt, const int64_t& timeout, 
+                            std::string& recordValue, int64_t& lastSequence, bool& fAuthoritative);
+    bool SubmitGetRecord(const size_t nSessionThread, const std::array<char, 32>& public_key, const std::array<char, 32>& private_seed, 
+                            const std::string& strOperationType, int64_t& iSequence, CDataRecord& record);
+    bool SubmitGetAllRecordsSync(const size_t nSessionThread, const std::vector<CLinkInfo>& vchLinkInfo, const std::string& strOperationType, std::vector<CDataRecord>& vchRecords);
+    bool SubmitGetAllRecordsAsync(const size_t nSessionThread, const std::vector<CLinkInfo>& vchLinkInfo, const std::string& strOperationType, std::vector<CDataRecord>& vchRecords);
+    bool GetAllDHTGetEvents(const size_t nSessionThread, std::vector<CMutableGetEvent>& vchGetEvents);
+    void GetDHTStats(const size_t nSessionThread, libtorrent::session_status& stats, std::vector<libtorrent::dht_lookup>& vchDHTLookup, std::vector<libtorrent::dht_routing_bucket>& vchDHTBuckets);
+}
 #endif // DYNAMIC_DHT_SESSION_H

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -87,6 +87,7 @@ public:
     void AddToEventMap(const int type, const CEvent& event);
     void CleanUpEventMap(const uint32_t timeout);
     void StopEventListener();
+    bool ReannounceEntry(const CMutableData& mutableData);
 
 private:
     bool GetDataFromMap(const std::array<char, 32>& public_key, const std::string& recordSalt, CMutableGetEvent& event);
@@ -123,6 +124,7 @@ namespace DHT
     bool SubmitGetAllRecordsAsync(const size_t nSessionThread, const std::vector<CLinkInfo>& vchLinkInfo, const std::string& strOperationType, std::vector<CDataRecord>& vchRecords);
     bool GetAllDHTGetEvents(const size_t nSessionThread, std::vector<CMutableGetEvent>& vchGetEvents);
     void GetDHTStats(CSessionStats& stats);
+    bool ReannounceEntry(const CMutableData& mutableData);
 }
 
 #endif // DYNAMIC_DHT_SESSION_H

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -14,8 +14,11 @@
 #include "libtorrent/session.hpp"
 #include "libtorrent/session_status.hpp"
 
+#include <map> // for std::map and std::multimap
+
 class CChainParams;
 class CConnman;
+class CEvent;
 class CKeyEd25519;
 class CLinkInfo;
 class CMutableGetEvent;
@@ -88,6 +91,7 @@ void StartTorrentDHTNetwork(const bool multithreads, const CChainParams& chainpa
 /** Stop the DHT libtorrent network threads */
 void StopTorrentDHTNetwork();
 void StartEventListener(std::shared_ptr<CHashTableSession> dhtSession);
+void ReannounceEntries();
 
 namespace DHT
 {

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -70,7 +70,6 @@ public:
     void StopEventListener();
 
 private:
-    
     bool GetDataFromMap(const std::array<char, 32>& public_key, const std::string& recordSalt, CMutableGetEvent& event);
     bool LoadSessionState();
     int SaveSessionState();

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -6,6 +6,8 @@
 #define DYNAMIC_DHT_SESSION_H
 
 #include "dht/datarecord.h"
+#include "dht/sessionevents.h"
+#include "sync.h"
 
 #include "libtorrent/alert.hpp"
 #include "libtorrent/alert_types.hpp"
@@ -22,6 +24,9 @@ namespace libtorrent {
     class entry;
 }
 
+typedef std::pair<int64_t, CEvent> EventPair;
+typedef std::multimap<int, EventPair> EventTypeMap;
+typedef std::map<std::string, CMutableGetEvent> DHTGetEventMap;
 
 static constexpr int DHT_GET_ALERT_TYPE_CODE = 75;
 static constexpr int DHT_PUT_ALERT_TYPE_CODE = 76;
@@ -40,6 +45,11 @@ public:
     std::map<HashRecordKey, int64_t> mPutCommands;
     std::string strPutErrorMessage;
     uint64_t nPutRecords;
+    bool fShutdown;
+    EventTypeMap m_EventTypeMap;
+    DHTGetEventMap m_DHTGetEventMap;
+    CCriticalSection cs_EventMap;
+    CCriticalSection cs_DHTGetEventMap;
 
     CHashTableSession() : vDataEntries(CDataRecordBuffer(32)), strPutErrorMessage(""), nPutRecords(0) {};
 
@@ -48,29 +58,37 @@ public:
     bool SubmitGet(const std::array<char, 32>& public_key, const std::string& recordSalt);
     bool SubmitGet(const std::array<char, 32>& public_key, const std::string& recordSalt, const int64_t& timeout, 
                             std::string& recordValue, int64_t& lastSequence, bool& fAuthoritative);
+    /** Get a mutable record in the libtorrent DHT */
     bool SubmitGetRecord(const std::array<char, 32>& public_key, const std::array<char, 32>& private_seed, const std::string& strOperationType, int64_t& iSequence, CDataRecord& record);
     bool SubmitGetAllRecordsAsync(const std::vector<CLinkInfo>& vchLinkInfo, const std::string& strOperationType, std::vector<CDataRecord>& vchRecords);
     bool SubmitGetAllRecordsSync(const std::vector<CLinkInfo>& vchLinkInfo, const std::string& strOperationType, std::vector<CDataRecord>& vchRecords);
+    void GetDHTStats(libtorrent::session_status& stats, std::vector<libtorrent::dht_lookup>& vchDHTLookup, std::vector<libtorrent::dht_routing_bucket>& vchDHTBuckets);
+    bool Bootstrap();
+    bool GetAllDHTGetEvents(std::vector<CMutableGetEvent>& vchGetEvents);
+    void AddToDHTGetEventMap(const std::string& infoHash, const CMutableGetEvent& event);
+    void AddToEventMap(const int type, const CEvent& event);
+    void CleanUpEventMap(const uint32_t timeout);
 
 private:
     void CleanUpPutCommandMap();
     int64_t GetLastPutDate(const HashRecordKey& recordKey);
     bool GetDataFromMap(const std::array<char, 32>& public_key, const std::string& recordSalt, CMutableGetEvent& event);
+    bool LoadSessionState();
+    int SaveSessionState();
+    std::string GetSessionStatePath();
+    bool RemoveDHTGetEvent(const std::string& infoHash);
+    void StopEventListener();
+    bool GetLastTypeEvent(const int& type, const int64_t& startTime, std::vector<CEvent>& events);
+    bool FindDHTGetEvent(const std::string& infoHash, CMutableGetEvent& event);
 
 };
-
-bool Bootstrap();
-bool LoadSessionState(libtorrent::session* dhtSession);
-int SaveSessionState(libtorrent::session* dhtSession);
-std::string GetSessionStatePath();
 
 /** Start the DHT libtorrent network threads */
 void StartTorrentDHTNetwork(const CChainParams& chainparams, CConnman& connman);
 /** Stop the DHT libtorrent network threads */
 void StopTorrentDHTNetwork();
-/** Get a mutable record in the libtorrent DHT */
-
-void GetDHTStats(libtorrent::session_status& stats, std::vector<libtorrent::dht_lookup>& vchDHTLookup, std::vector<libtorrent::dht_routing_bucket>& vchDHTBuckets);
+void StartEventListener(CHashTableSession* dhtSession);
+void StopEventListener();
 
 extern CHashTableSession* pHashTableSession;
 

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -11,6 +11,7 @@
 
 #include "libtorrent/alert.hpp"
 #include "libtorrent/alert_types.hpp"
+#include "libtorrent/fwd.hpp"
 #include "libtorrent/session.hpp"
 #include "libtorrent/session_status.hpp"
 
@@ -21,10 +22,13 @@ class CConnman;
 class CEvent;
 class CKeyEd25519;
 class CLinkInfo;
+class CMutableData;
 class CMutableGetEvent;
 
 namespace libtorrent {
-    class entry;
+    namespace dht {
+        class item;
+    }
 }
 
 typedef std::pair<int64_t, CEvent> EventPair;
@@ -92,6 +96,7 @@ void StartTorrentDHTNetwork(const bool multithreads, const CChainParams& chainpa
 void StopTorrentDHTNetwork();
 void StartEventListener(std::shared_ptr<CHashTableSession> dhtSession);
 void ReannounceEntries();
+bool ConvertMutableEntry(const CMutableData& mut_data, libtorrent::dht::item& mut_item);
 
 namespace DHT
 {

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -88,6 +88,7 @@ public:
     void CleanUpEventMap(const uint32_t timeout);
     void StopEventListener();
     bool ReannounceEntry(const CMutableData& mutableData);
+    void GetEvents(const int64_t& startTime, std::vector<CEvent>& events);
 
 private:
     bool GetDataFromMap(const std::array<char, 32>& public_key, const std::string& recordSalt, CMutableGetEvent& event);
@@ -125,6 +126,8 @@ namespace DHT
     bool GetAllDHTGetEvents(const size_t nSessionThread, std::vector<CMutableGetEvent>& vchGetEvents);
     void GetDHTStats(CSessionStats& stats);
     bool ReannounceEntry(const CMutableData& mutableData);
+    void GetEvents(const int64_t& startTime, std::vector<CEvent>& events);
+
 }
 
 #endif // DYNAMIC_DHT_SESSION_H

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -50,7 +50,7 @@ public:
     CCriticalSection cs_EventMap;
     CCriticalSection cs_DHTGetEventMap;
 
-    CHashTableSession() : vDataEntries(CDataRecordBuffer(32)), strErrorMessage("") {};
+    CHashTableSession() : vDataEntries(CDataRecordBuffer(32)), strErrorMessage(""), fShutdown(false) {};
 
     bool SubmitPut(const std::array<char, 32> public_key, const std::array<char, 64> private_key, const int64_t lastSequence, const std::string& strSalt, const libtorrent::entry& entryValue);
 

--- a/src/dht/session.h
+++ b/src/dht/session.h
@@ -40,6 +40,7 @@ typedef std::pair<std::array<char, 32>, std::string> HashRecordKey; // public ke
 
 class CHashTableSession {
 public:
+    std::string strName;
     CDataRecordBuffer vDataEntries;
     libtorrent::session* Session = NULL;
     std::map<HashRecordKey, int64_t> mPutCommands;
@@ -90,6 +91,7 @@ void StopTorrentDHTNetwork();
 void StartEventListener(CHashTableSession* dhtSession);
 void StopEventListener();
 
-extern CHashTableSession* pHashTableSession;
+extern CHashTableSession* pHashTableSessionGet;
+extern CHashTableSession* pHashTableSessionPut;
 
 #endif // DYNAMIC_DHT_SESSION_H

--- a/src/dht/sessionevents.cpp
+++ b/src/dht/sessionevents.cpp
@@ -12,6 +12,7 @@
 #include <libtorrent/alert_types.hpp>
 #include <libtorrent/kademlia/types.hpp>
 #include <libtorrent/kademlia/item.hpp>
+#include <libtorrent/hasher.hpp> // for to_hex and from_hex
 #include <libtorrent/hex.hpp> // for to_hex and from_hex
 #include <libtorrent/session.hpp>
 #include <libtorrent/session_status.hpp>
@@ -43,13 +44,21 @@ std::string GetInfoHash(const std::string& pubkey, const std::string& salt)
     dht::public_key pk;
     pk.bytes = arrPubKey;
     const sha1_hash infoHash = dht::item_target_id(salt, pk);
-    
     return aux::to_hex(infoHash.to_string());
+}
+
+std::string GetDynodeHashID(const std::string& outpoint)
+{
+    hasher hashNodeID(outpoint.c_str(), outpoint.size());
+    const sha1_hash nodeID = hashNodeID.final();
+    LogPrintf("%s -- Dynode Outpoint %s,  HashID %s\n\n", __func__, outpoint, aux::to_hex(nodeID.to_string()));
+    return aux::to_hex(nodeID.to_string());
 }
 
 CMutableGetEvent::CMutableGetEvent() : CEvent()
 {
 }
+
 CMutableGetEvent::CMutableGetEvent(const std::string& _message, const int _type, const uint32_t _category, const std::string& _what, 
                                    const std::string& _pubkey, const std::string& _salt, const int64_t& _seq, const std::string& _value, const std::string& _signature, const bool _authoritative)
                 : CEvent(_message, _type, _category, _what)

--- a/src/dht/sessionevents.cpp
+++ b/src/dht/sessionevents.cpp
@@ -4,7 +4,6 @@
 
 #include "dht/sessionevents.h"
 
-#include "dht/session.h"
 #include "sync.h" // for LOCK and CCriticalSection
 #include "util.h" // for LogPrintf
 #include "utiltime.h" // for GetTimeMillis
@@ -22,16 +21,9 @@
 
 using namespace libtorrent;
 
-typedef std::pair<int64_t, CEvent> EventPair;
-typedef std::multimap<int, EventPair> EventTypeMap;
-typedef std::map<std::string, CMutableGetEvent> DHTGetEventMap;
 
-static CCriticalSection cs_EventMap;
-static CCriticalSection cs_DHTGetEventMap;
 
-static bool fShutdown;
-static EventTypeMap m_EventTypeMap;
-static DHTGetEventMap m_DHTGetEventMap;
+
 
 CEvent::CEvent(const std::string& _message, const int _type, const uint32_t _category, const std::string& _what)
 {
@@ -94,165 +86,4 @@ CPutRequest::CPutRequest(const CKeyEd25519& _key, const std::string& _salt, cons
     sequence = _sequence;
     value = _value;
     timestamp = GetTimeMillis();
-}
-
-void AddToDHTGetEventMap(const std::string& infoHash, const CMutableGetEvent& event)
-{
-    LOCK(cs_DHTGetEventMap);
-    if (m_DHTGetEventMap.find(infoHash) == m_DHTGetEventMap.end()) {
-        // event not found. Add a new entry to DHT event map
-        LogPrint("dht", "AddToDHTGetEventMap Not found -- infohash = %s\n", infoHash);
-        m_DHTGetEventMap.insert(std::make_pair(infoHash, event));
-    }
-    else {
-        // event found. Update entry in DHT event map
-        LogPrint("dht", "AddToDHTGetEventMap Found -- Updateinfohash = %s\n", infoHash);
-        m_DHTGetEventMap[infoHash] = event;
-    }
-}
-
-static void AddToEventMap(const int type, const CEvent& event)
-{
-    LOCK(cs_EventMap);
-    m_EventTypeMap.insert(std::make_pair(type, std::make_pair(event.Timestamp(), event)));
-}
-
-static void DHTEventListener(session* dhtSession)
-{
-    SetThreadPriority(THREAD_PRIORITY_LOWEST);
-    RenameThread("dht-events");
-    unsigned int counter = 0;
-    while(!fShutdown)
-    {
-        if (!dhtSession->is_dht_running()) {
-            LogPrint("dht", "%s -- DHT is not running yet\n", __func__);
-            MilliSleep(2000);
-            continue;
-        }
-
-        dhtSession->wait_for_alert(seconds(1));
-        std::vector<alert*> alerts;
-        dhtSession->pop_alerts(&alerts);
-        for (std::vector<alert*>::iterator iAlert = alerts.begin(), end(alerts.end()); iAlert != end; ++iAlert) {
-            if ((*iAlert) == nullptr)
-                continue;
-
-            const uint32_t iAlertCategory = (*iAlert)->category();
-            const std::string strAlertMessage = (*iAlert)->message();
-            const int iAlertType = (*iAlert)->type();
-            const std::string strAlertTypeName = alert_name(iAlertType);
-            if (iAlertType == DHT_GET_ALERT_TYPE_CODE || iAlertType == DHT_PUT_ALERT_TYPE_CODE) {
-                if (iAlertType == DHT_GET_ALERT_TYPE_CODE) {
-                    // DHT Get Mutable Event
-                    dht_mutable_item_alert* pGet = alert_cast<dht_mutable_item_alert>((*iAlert));
-                    if (pGet == nullptr)
-                        continue;
-                    LogPrint("dht", "%s -- PubKey = %s, Salt = %s, Value = %s\nMessage = %s, Alert Type =%s, Alert Category = %u\n"
-                        , __func__, aux::to_hex(pGet->key), pGet->salt, pGet->item.to_string(), strAlertMessage, strAlertTypeName, iAlertCategory);
-
-                    if (pGet->item.to_string() != "<uninitialized>") {
-                        const CMutableGetEvent event(strAlertMessage, iAlertType, iAlertCategory, strAlertTypeName, 
-                          aux::to_hex(pGet->key), pGet->salt, pGet->seq, pGet->item.to_string(), aux::to_hex(pGet->signature), pGet->authoritative);
-
-                        std::string infoHash = GetInfoHash(event.PublicKey(), event.Salt());
-                        AddToDHTGetEventMap(infoHash, event);
-                    }
-                }
-            }
-            else if (iAlertType == DHT_STATS_ALERT_TYPE_CODE) {
-                // TODO (dht): handle stats 
-                //dht_stats_alert* pAlert = alert_cast<dht_stats_alert>((*iAlert));
-                LogPrintf("%s -- DHT Alert Message: AlertType = %s\n", __func__, strAlertTypeName); 
-            }
-            else {
-                const CEvent event(strAlertMessage, iAlertType, iAlertCategory, strAlertTypeName);
-                AddToEventMap(iAlertType, event);
-            }
-        }
-        if (fShutdown)
-            return;
-        
-        counter++;
-        if (counter % 60 == 0) {
-            LogPrint("dht", "DHTEventListener -- Before CleanUpEventMap. counter = %u\n", counter);
-            CleanUpEventMap(300000);
-        }
-    }
-}
-
-void CleanUpEventMap(const uint32_t timeout)
-{
-    unsigned int deleted = 0;
-    unsigned int counter = 0;
-    int64_t iTime = GetTimeMillis();
-    LOCK(cs_EventMap);
-    for (auto it = m_EventTypeMap.begin(); it != m_EventTypeMap.end(); ) {
-        CEvent event = it->second.second;
-        if ((iTime - event.Timestamp()) > timeout) {
-            it = m_EventTypeMap.erase(it);
-            deleted++;
-        }
-        else {
-            ++it;
-        }
-        counter++;
-    }
-    LogPrint("dht", "DHTEventListener -- CleanUpEventMap. deleted = %u, count = %u\n", deleted, counter);
-}
-
-void StopEventListener()
-{
-	fShutdown = true;
-    LogPrint("dht", "DHTEventListener -- stopping.\n");
-    MilliSleep(2100);
-}
-
-void StartEventListener(session* dhtSession)
-{
-    LogPrint("dht", "StartEventListener -- start\n");
-    fShutdown = false;
-    DHTEventListener(dhtSession);
-}
-
-bool GetLastTypeEvent(const int& type, const int64_t& startTime, std::vector<CEvent>& events)
-{
-    //LOCK(cs_EventMap);
-    LogPrint("dht", "GetLastTypeEvent -- m_EventTypeMap.size = %u, type = %u.\n", m_EventTypeMap.size(), type);
-    std::multimap<int, EventPair>::iterator iEvents = m_EventTypeMap.find(type);
-    while (iEvents != m_EventTypeMap.end()) {
-        if (iEvents->second.first >= startTime) {
-            events.push_back(iEvents->second.second);
-        }
-        iEvents++;
-    }
-    LogPrint("dht", "GetLastTypeEvent -- events.size() = %u\n", events.size());
-    return events.size() > 0;
-}
-
-bool FindDHTGetEvent(const std::string& infoHash, CMutableGetEvent& event)
-{
-    //LOCK(cs_DHTGetEventMap);
-    std::map<std::string, CMutableGetEvent>::iterator iMutableEvent = m_DHTGetEventMap.find(infoHash);
-    if (iMutableEvent != m_DHTGetEventMap.end()) {
-        // event found.
-        event = iMutableEvent->second;
-        return true;
-    }
-    return false;
-}
-
-bool RemoveDHTGetEvent(const std::string& infoHash)
-{
-    LOCK(cs_DHTGetEventMap);
-    m_DHTGetEventMap.erase(infoHash);
-    return true;
-}
-
-bool GetAllDHTGetEvents(std::vector<CMutableGetEvent>& vchGetEvents)
-{
-    //LOCK(cs_DHTGetEventMap);
-    for (std::map<std::string, CMutableGetEvent>::iterator it=m_DHTGetEventMap.begin(); it!=m_DHTGetEventMap.end(); ++it) {
-        vchGetEvents.push_back(it->second);
-    }
-    return true;
 }

--- a/src/dht/sessionevents.cpp
+++ b/src/dht/sessionevents.cpp
@@ -21,10 +21,6 @@
 
 using namespace libtorrent;
 
-
-
-
-
 CEvent::CEvent(const std::string& _message, const int _type, const uint32_t _category, const std::string& _what)
 {
     message = _message;

--- a/src/dht/sessionevents.cpp
+++ b/src/dht/sessionevents.cpp
@@ -47,11 +47,11 @@ std::string GetInfoHash(const std::string& pubkey, const std::string& salt)
     return aux::to_hex(infoHash.to_string());
 }
 
-std::string GetDynodeHashID(const std::string& outpoint)
+std::string GetDynodeHashID(const std::string& service_address)
 {
-    hasher hashNodeID(outpoint.c_str(), outpoint.size());
+    hasher hashNodeID(service_address.c_str(), service_address.size());
     const sha1_hash nodeID = hashNodeID.final();
-    LogPrintf("%s -- Dynode Outpoint %s,  HashID %s\n\n", __func__, outpoint, aux::to_hex(nodeID.to_string()));
+    LogPrintf("%s -- Dynode Service Address %s,  HashID %s\n", __func__, service_address, aux::to_hex(nodeID.to_string()));
     return aux::to_hex(nodeID.to_string());
 }
 

--- a/src/dht/sessionevents.cpp
+++ b/src/dht/sessionevents.cpp
@@ -18,8 +18,6 @@
 #include <libtorrent/session_status.hpp>
 #include <libtorrent/time.hpp>
 
-#include <map>
-
 using namespace libtorrent;
 
 CEvent::CEvent(const std::string& _message, const int _type, const uint32_t _category, const std::string& _what)

--- a/src/dht/sessionevents.h
+++ b/src/dht/sessionevents.h
@@ -155,6 +155,6 @@ public:
 };
 
 std::string GetInfoHash(const std::string& pubkey, const std::string& salt);
-std::string GetDynodeHashID(const std::string& outpoint);
+std::string GetDynodeHashID(const std::string& service_address);
 
 #endif // DYNAMIC_DHT_SESSION_EVENTS_H

--- a/src/dht/sessionevents.h
+++ b/src/dht/sessionevents.h
@@ -154,16 +154,6 @@ public:
     }
 };
 
-void CleanUpEventMap(const uint32_t timeout = 300000);  //default to 5 minutes.
-void AddToDHTGetEventMap(const std::string& infoHash, const CMutableGetEvent& event);
-
-void StopEventListener();
-void StartEventListener(libtorrent::session* dhtSession);
-
-bool GetLastTypeEvent(const int& type, const int64_t& startTime, std::vector<CEvent>& events);
-bool FindDHTGetEvent(const std::string& infoHash, CMutableGetEvent& event);
-bool RemoveDHTGetEvent(const std::string& infoHash);
-bool GetAllDHTGetEvents(std::vector<CMutableGetEvent>& vchGetEvents);
 std::string GetInfoHash(const std::string& pubkey, const std::string& salt);
 
 #endif // DYNAMIC_DHT_SESSION_EVENTS_H

--- a/src/dht/sessionevents.h
+++ b/src/dht/sessionevents.h
@@ -11,8 +11,8 @@
 #include <vector>
 
 namespace libtorrent {
-    class session;
     class alert;
+    class session;
 }
 
 class CEvent {
@@ -155,5 +155,6 @@ public:
 };
 
 std::string GetInfoHash(const std::string& pubkey, const std::string& salt);
+std::string GetDynodeHashID(const std::string& outpoint);
 
 #endif // DYNAMIC_DHT_SESSION_EVENTS_H

--- a/src/dht/settings.cpp
+++ b/src/dht/settings.cpp
@@ -18,7 +18,7 @@ using namespace libtorrent;
 
 CDHTSettings::CDHTSettings(const uint16_t nSessionNumber)
 {
-    nPort = Params().GetDefaultPort() + (nSessionNumber + 10);
+    nPort = Params().GetDefaultPort() + (nSessionNumber + 11);
     user_agent = "Dynamic v" + FormatFullVersion();
     // Uses UDP port 33311 for mainnet, 333411 for testnet, 33511 for regtest, or 33611 for privatenet
     listen_interfaces = "0.0.0.0:" + std::to_string(nPort) + ",[::]:" + std::to_string(nPort);

--- a/src/dht/settings.cpp
+++ b/src/dht/settings.cpp
@@ -73,6 +73,12 @@ void CDHTSettings::LoadPeerList()
     LogPrintf("CDHTSettings::LoadPeerList -- dht_bootstrap_nodes = %s\n", dht_bootstrap_nodes);
 }
 
+void CDHTSettings::LoadPeerID(const std::string& strPeerID)
+{
+    peer_fingerprint = strPeerID;
+    LogPrintf("CDHTSettings::%s -- peer_fingerprint = %s\n", __func__, peer_fingerprint);
+}
+
 void CDHTSettings::LoadSettings()
 {
     LoadPeerList();
@@ -88,6 +94,8 @@ void CDHTSettings::LoadSettings()
         params.settings.set_str(settings_pack::user_agent, user_agent);
         params.settings.set_str(settings_pack::dht_bootstrap_nodes, dht_bootstrap_nodes); 
         params.settings.set_str(settings_pack::listen_interfaces, listen_interfaces);
+        if (peer_fingerprint.size() > 0)
+            params.settings.set_str(settings_pack::peer_fingerprint, peer_fingerprint);
         params.dht_settings.max_peers_reply = 100; // default = 100
         params.dht_settings.search_branching = 10; // default = 5
         params.dht_settings.max_fail_count = 100; // default = 20

--- a/src/dht/settings.cpp
+++ b/src/dht/settings.cpp
@@ -16,9 +16,9 @@
 
 using namespace libtorrent;
 
-CDHTSettings::CDHTSettings()
+CDHTSettings::CDHTSettings(const uint16_t nSessionNumber)
 {
-    nPort = Params().GetDefaultPort() + 11;
+    nPort = Params().GetDefaultPort() + (nSessionNumber + 10);
     user_agent = "Dynamic v" + FormatFullVersion();
     // Uses UDP port 33311 for mainnet, 333411 for testnet, 33511 for regtest, or 33611 for privatenet
     listen_interfaces = "0.0.0.0:" + std::to_string(nPort) + ",[::]:" + std::to_string(nPort);

--- a/src/dht/settings.cpp
+++ b/src/dht/settings.cpp
@@ -42,7 +42,6 @@ CDHTSettings::CDHTSettings(const uint16_t ordinal, const uint16_t threads, const
 
 void CDHTSettings::LoadPeerList()
 {
-    LogPrintf("DEBUGGER - %s - Begin, nTotalThreads = %d\n", __func__, nTotalThreads);
     std::string strPeerList = "";
     // get all Dynodes above the minimum protocol version
     std::map<COutPoint, CDynode> mapDynodes = dnodeman.GetFullDynodeMap();

--- a/src/dht/settings.h
+++ b/src/dht/settings.h
@@ -19,7 +19,7 @@ private:
     uint16_t nPort;
 
 public:
-    CDHTSettings();
+    CDHTSettings(const uint16_t nSessionNumber);
 
     void LoadSettings();
 

--- a/src/dht/settings.h
+++ b/src/dht/settings.h
@@ -17,9 +17,11 @@ private:
     std::string dht_bootstrap_nodes;
     std::string user_agent;
     uint16_t nPort;
+    uint16_t nTotalThreads;
+    bool fMultiThreads;
 
 public:
-    CDHTSettings(const uint16_t nSessionNumber);
+    CDHTSettings(const uint16_t ordinal, const uint16_t threads, const bool multithreaded);
 
     void LoadSettings();
 

--- a/src/dht/settings.h
+++ b/src/dht/settings.h
@@ -16,6 +16,7 @@ private:
     std::string listen_interfaces;
     std::string dht_bootstrap_nodes;
     std::string user_agent;
+    std::string peer_fingerprint;
     uint16_t nPort;
     uint16_t nTotalThreads;
     bool fMultiThreads;
@@ -24,6 +25,7 @@ public:
     CDHTSettings(const uint16_t ordinal, const uint16_t threads, const bool multithreaded);
 
     void LoadSettings();
+    void LoadPeerID(const std::string& strPeerID);
 
     libtorrent::settings_pack GetSettingsPack() const { return params.settings; }
     libtorrent::dht_settings GetDHTSettings() const { return params.dht_settings; }

--- a/src/dht/storage.cpp
+++ b/src/dht/storage.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "storage.h"
+#include "dht/storage.h"
 
 #include "bdap/utils.h"
 #include "dht/ed25519.h"

--- a/src/dht/storage.cpp
+++ b/src/dht/storage.cpp
@@ -194,17 +194,17 @@ void CDHTStorage::put_mutable_item(sha1_hash const& target
     CMutableData previousData;
     if (!GetLocalMutableData(vchInfoHash, previousData)) {
         if (PutLocalMutableData(vchInfoHash, putMutableData)) {
-            LogPrint("dht", "CDHTStorage -- put_mutable_item added successfully\n");
+            LogPrintf("CDHTStorage::%s added successfully\n", __func__);
         }
     }
     else {
-        if (putMutableData.Value() != previousData.Value() || putMutableData.SequenceNumber != previousData.SequenceNumber) {
+        if (putMutableData.SequenceNumber > previousData.SequenceNumber) {
             if (UpdateLocalMutableData(vchInfoHash, putMutableData)) {
-                LogPrint("dht", "CDHTStorage -- put_mutable_item updated successfully\n");
+                LogPrintf("CDHTStorage::%s updated successfully\n", __func__);
             }
         }
         else {
-            LogPrint("dht", "CDHTStorage -- put_mutable_item value unchanged. No database operation needed.\n");
+            LogPrintf("CDHTStorage::%s value unchanged. No database operation needed.\n", __func__);
         }
     }
     // TODO: Log from address (addr). See touch_item in the default storage implementation.

--- a/src/dht/storage.cpp
+++ b/src/dht/storage.cpp
@@ -187,8 +187,8 @@ void CDHTStorage::put_mutable_item(sha1_hash const& target
     CharString vchSalt = vchFromString(strSalt);
 
     CMutableData putMutableData(vchInfoHash, vchPublicKey, vchSignature, seq.value, vchSalt, vchPutValue);
-    LogPrint("dht", "CDHTStorage -- put_mutable_item info_hash = %s, buf_value = %s, salt = %s, seq = %d, put_size = %d, sig_size = %d, pubkey_size = %d, salt_size = %d\n", 
-                    strInfoHash, strPutValue, strSalt, putMutableData.SequenceNumber, 
+    LogPrintf("CDHTStorage::%s -- put_mutable_item info_hash = %s, buf_value = %s, salt = %s, seq = %d, put_size = %d, sig_size = %d, pubkey_size = %d, salt_size = %d\n", 
+                    __func__, strInfoHash, strPutValue, strSalt, putMutableData.SequenceNumber, 
                     vchPutValue.size(), vchSignature.size(), vchPublicKey.size(), vchSalt.size());
 
     CMutableData previousData;

--- a/src/dht/storage.cpp
+++ b/src/dht/storage.cpp
@@ -172,6 +172,7 @@ void CDHTStorage::put_mutable_item(sha1_hash const& target
     CharString vchPublicKey = vchFromString(strPublicKey);
     if (!CheckPubKey(vchPublicKey)) {
         LogPrintf("%s -- Invalid pubkey used (%s).  DHT put storage request failed.\n", __func__, strPublicKey);
+        return;
     }
     std::unique_ptr<char[]> saltValue;
     ExtractValueFromSpan(saltValue, salt);
@@ -180,7 +181,8 @@ void CDHTStorage::put_mutable_item(sha1_hash const& target
     std::string strErrorMessage;
     unsigned int nHeight = (unsigned int)chainActive.Height();
     if (!CheckSalt(strSalt, nHeight, strErrorMessage)) {
-        LogPrintf("%s -- Invalid salt used (%s) at height %d.  DHT put storage request failed.\n", __func__, strSalt, nHeight);
+        LogPrintf("%s -- Invalid salt used (%s) at height %d.  DHT put storage request failed. %s\n", __func__, strSalt, nHeight, strErrorMessage);
+        return;
     }
     CharString vchSalt = vchFromString(strSalt);
 

--- a/src/dht/storage.cpp
+++ b/src/dht/storage.cpp
@@ -155,6 +155,8 @@ void CDHTStorage::put_mutable_item(sha1_hash const& target
     // TODO (DHT): Store entries in memory as well
     //pDefaultStorage->put_mutable_item(target, buf, sig, seq, pk, salt, addr);
 
+    // check if the public key belongs to an account or link
+    // check if salt is allowed
     std::string strInfoHash = aux::to_hex(target.to_string());
     CharString vchInfoHash = vchFromString(strInfoHash);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -375,8 +375,10 @@ void PrepareShutdown()
         delete pLinkManager;
         pLinkManager = NULL;
         // LibTorrent DHT Netowrk Services
-        delete pHashTableSession;
-        pHashTableSession = NULL;
+        delete pHashTableSessionGet;
+        pHashTableSessionGet = NULL;
+        delete pHashTableSessionPut;
+        pHashTableSessionPut = NULL;
         delete pMutableDataDB;
         pMutableDataDB = NULL;
     }
@@ -1726,7 +1728,8 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 delete pLinkDB;
                 delete pLinkManager;
                 // LibTorrent DHT Netowrk Services
-                delete pHashTableSession;
+                delete pHashTableSessionGet;
+                delete pHashTableSessionPut;
                 delete pMutableDataDB;
 
                 pblocktree = new CBlockTreeDB(nBlockTreeDBCache, false, fReindex);
@@ -1746,7 +1749,8 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 pLinkDB = new CLinkDB(nTotalCache * 35, false, fReindex, obfuscate);
                 pLinkManager = new CLinkManager();
                 // Init DHT Services DB
-                pHashTableSession = new CHashTableSession();
+                pHashTableSessionGet = new CHashTableSession();
+                pHashTableSessionPut = new CHashTableSession();
                 pMutableDataDB = new CMutableDataDB(nTotalCache * 35, false, fReindex, obfuscate);
 
                 if (fReindex) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2120,7 +2120,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     // Start the DHT Torrent networks in the background
-    const bool fMultiSessions = GetArg("-multidhtsessions", false);
+    const bool fMultiSessions = GetArg("-multidhtsessions", true);
     StartTorrentDHTNetwork(fMultiSessions, chainparams, connman);
     // ********************************************************* Step 13: finished
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2120,7 +2120,8 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     // Start the DHT Torrent networks in the background
-    StartTorrentDHTNetwork(chainparams, connman);
+    const bool fMultiSessions = GetArg("-multidhtsessions", false);
+    StartTorrentDHTNetwork(fMultiSessions, chainparams, connman);
     // ********************************************************* Step 13: finished
 
     SetRPCWarmupFinished();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2123,7 +2123,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         StartMiners();
     }
 
-    // Start the DHT Torrent network in the background
+    // Start the DHT Torrent networks in the background
     StartTorrentDHTNetwork(chainparams, connman);
     // ********************************************************* Step 13: finished
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -370,10 +370,8 @@ void PrepareShutdown()
         // BDAP Services DB's
         delete pDomainEntryDB;
         pDomainEntryDB = NULL;
-        delete pLinkRequestDB;
-        pLinkRequestDB = NULL;
-        delete pLinkAcceptDB;
-        pLinkAcceptDB = NULL;
+        delete pLinkDB;
+        pLinkDB = NULL;
         delete pLinkManager;
         pLinkManager = NULL;
         // LibTorrent DHT Netowrk Services
@@ -1725,8 +1723,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 delete pBanAccountDB;
                 // BDAP Services DB's
                 delete pDomainEntryDB;
-                delete pLinkRequestDB;
-                delete pLinkAcceptDB;
+                delete pLinkDB;
                 delete pLinkManager;
                 // LibTorrent DHT Netowrk Services
                 delete pHashTableSession;
@@ -1746,8 +1743,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 pBanAccountDB = new CBanAccountDB(nTotalCache * 35, false, fReindex, obfuscate);
                 // Init BDAP Services DBs 
                 pDomainEntryDB = new CDomainEntryDB(nTotalCache * 35, false, fReindex, obfuscate);
-                pLinkRequestDB = new CLinkRequestDB(nTotalCache * 35, false, fReindex, obfuscate);
-                pLinkAcceptDB = new CLinkAcceptDB(nTotalCache * 35, false, fReindex, obfuscate);
+                pLinkDB = new CLinkDB(nTotalCache * 35, false, fReindex, obfuscate);
                 pLinkManager = new CLinkManager();
                 // Init DHT Services DB
                 pHashTableSession = new CHashTableSession();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -375,10 +375,6 @@ void PrepareShutdown()
         delete pLinkManager;
         pLinkManager = NULL;
         // LibTorrent DHT Netowrk Services
-        delete pHashTableSessionGet;
-        pHashTableSessionGet = NULL;
-        delete pHashTableSessionPut;
-        pHashTableSessionPut = NULL;
         delete pMutableDataDB;
         pMutableDataDB = NULL;
     }
@@ -1728,8 +1724,6 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 delete pLinkDB;
                 delete pLinkManager;
                 // LibTorrent DHT Netowrk Services
-                delete pHashTableSessionGet;
-                delete pHashTableSessionPut;
                 delete pMutableDataDB;
 
                 pblocktree = new CBlockTreeDB(nBlockTreeDBCache, false, fReindex);
@@ -1749,8 +1743,6 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 pLinkDB = new CLinkDB(nTotalCache * 35, false, fReindex, obfuscate);
                 pLinkManager = new CLinkManager();
                 // Init DHT Services DB
-                pHashTableSessionGet = new CHashTableSession();
-                pHashTableSessionPut = new CHashTableSession();
                 pMutableDataDB = new CMutableDataDB(nTotalCache * 35, false, fReindex, obfuscate);
 
                 if (fReindex) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -598,7 +598,7 @@ std::string GenerateRandomString(unsigned int len) {
     return strPassword;
 }
 
-static unsigned int RandomIntegerRange(unsigned int nMin, unsigned int nMax)
+unsigned int RandomIntegerRange(unsigned int nMin, unsigned int nMax)
 {
     srand(time(NULL) + nMax); //seed srand before using
     return nMin + rand() % (nMax - nMin) + 1;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -600,6 +600,9 @@ std::string GenerateRandomString(unsigned int len) {
 
 unsigned int RandomIntegerRange(unsigned int nMin, unsigned int nMax)
 {
+    if (nMin == nMax)
+        return nMax;
+
     srand(time(NULL) + nMax); //seed srand before using
     return nMin + rand() % (nMax - nMin) + 1;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -152,6 +152,7 @@ boost::filesystem::path GetDefaultDataDir();
 const boost::filesystem::path& GetDataDir(bool fNetSpecific = true);
 boost::filesystem::path GetBackupsDir();
 std::string GenerateRandomString(unsigned int len);
+unsigned int RandomIntegerRange(unsigned int nMin, unsigned int nMax);
 void ClearDatadirCache();
 boost::filesystem::path GetConfigFile(const std::string& confPath);
 boost::filesystem::path GetDynodeConfigFile();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -676,7 +676,7 @@ bool ValidateBDAPInputs(const CTransactionRef& tx, CValidationState& state, cons
                     return state.DoS(100, false, REJECT_INVALID, errorMessage);
                 }
                 uint256 txid;
-                if (GetLinkRequestIndex(vchPubKey, txid)) {
+                if (GetLinkIndex(vchPubKey, txid)) {
                     if (txid != tx->GetHash()) {
                         errorMessage = "Link request public key already used.";
                         LogPrintf("%s -- %s\n", __func__, errorMessage);
@@ -694,7 +694,7 @@ bool ValidateBDAPInputs(const CTransactionRef& tx, CValidationState& state, cons
                     return state.DoS(100, false, REJECT_INVALID, errorMessage);
                 }
                 uint256 txid;
-                if (GetLinkAcceptIndex(vchPubKey, txid)) {
+                if (GetLinkIndex(vchPubKey, txid)) {
                     if (txid != tx->GetHash()) {
                         errorMessage = "Link accept public key already used.";
                         return state.DoS(100, false, REJECT_INVALID, errorMessage);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3770,7 +3770,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 }
                 else if (strOpType == "bdap_new_link_request") {
                     uint256 txid;
-                    if (GetLinkRequestIndex(vchValue, txid)) {
+                    if (GetLinkIndex(vchValue, txid)) {
                         strFailReason = _("Public key already used for a link request.");
                         return false;
                     }
@@ -3778,7 +3778,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 }
                 else if (strOpType == "bdap_new_link_accept") {
                     uint256 txid;
-                    if (GetLinkAcceptIndex(vchValue, txid)) {
+                    if (GetLinkIndex(vchValue, txid)) {
                         strFailReason = _("Public key already used for an accepted link.");
                         return false;
                     }
@@ -3786,7 +3786,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 }
                 else if (strOpType == "bdap_delete_link_request") {
                     uint256 prevTxId;
-                    if (!GetLinkRequestIndex(vchValue, prevTxId)) {
+                    if (!GetLinkIndex(vchValue, prevTxId)) {
                         strFailReason = _("Link accept pubkey could not be found.");
                         return false;
                     }
@@ -3801,7 +3801,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 }
                 else if (strOpType == "bdap_delete_link_accept") {
                     uint256 prevTxId;
-                    if (!GetLinkAcceptIndex(vchValue, prevTxId)) {
+                    if (!GetLinkIndex(vchValue, prevTxId)) {
                         strFailReason = _("Link accept pubkey could not be found.");
                         return false;
                     }


### PR DESCRIPTION
- Consolidate link public key database into one leveldb directory and class.
- Use multiple sessions and ports for the DHT put and get commands.
- Allow single or multithreaded get and put operations by using `multidhtsessions`
- Restrict DHT data by record type and BDAP account pubkey and link pubkey databases
- Dynodes use static peer ID for the DHT by hashing the outpoint it uses.
- Remove unnecessary debug log printing.
- Fix `dhtdb` RPC command daemon output by displaying base64 encoded values.
- Correct some include headers in sub-directories by using full path
- Use Dynode service address instead of outpoint for peer id
- Use mainline incompatible DHT messages
- Add BDAP fee start and end height to prepare for fluid changes
- Re-announce DHT entries every minute in a background thread
- Add `dht reannounce` RPC command
- Add `dht events` RPC command
- Only update put when sequence is greater than previous
- Default to multiple thread sessions