### PR TITLE
Lower size of keypools

### DIFF
--- a/src/privatesend-client.h
+++ b/src/privatesend-client.h
@@ -33,9 +33,9 @@ static const bool DEFAULT_PRIVATESEND_MULTISESSION = false;
 
 // Warn user if mixing in gui or try to create backup if mixing in daemon mode
 // when we have only this many keys left
-static const int PRIVATESEND_KEYS_THRESHOLD_WARNING = 100;
+static const int PRIVATESEND_KEYS_THRESHOLD_WARNING = 50;
 // Stop mixing completely, it's too dangerous to continue when we have only this many keys left
-static const int PRIVATESEND_KEYS_THRESHOLD_STOP = 50;
+static const int PRIVATESEND_KEYS_THRESHOLD_STOP = 25;
 
 // The main object for accessing mixing
 extern CPrivateSendClientManager privateSendClient;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -626,12 +626,6 @@ static bool IsCurrentForFeeEstimation()
 // Check if BDAP entry is valid
 bool ValidateBDAPInputs(const CTransactionRef& tx, CValidationState& state, const CCoinsViewCache& inputs, const CBlock& block, bool fJustCheck, int nHeight, bool bSanity)
 {
-    // TODO:    fLoaded not set to true until AFTER we're called during init. 
-    //          may need to revisit. comment out for now.
-    // Do not check while wallet is loading
-    // if (!fLoaded)
-    //     return true;
-
     if (!CheckDomainEntryDB())
         return true;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -626,9 +626,11 @@ static bool IsCurrentForFeeEstimation()
 // Check if BDAP entry is valid
 bool ValidateBDAPInputs(const CTransactionRef& tx, CValidationState& state, const CCoinsViewCache& inputs, const CBlock& block, bool fJustCheck, int nHeight, bool bSanity)
 {
+    // TODO:    fLoaded not set to true until AFTER we're called during init. 
+    //          may need to revisit. comment out for now.
     // Do not check while wallet is loading
-    if (!fLoaded)
-        return true;
+    // if (!fLoaded)
+    //     return true;
 
     if (!CheckDomainEntryDB())
         return true;
@@ -1946,7 +1948,7 @@ static DisconnectResult DisconnectBlock(const CBlock& block, CValidationState& s
         uint256 hash = tx.GetHash();
         bool is_coinbase = tx.IsCoinBase();
         bool fIsBDAP = tx.nVersion == BDAP_TX_VERSION;
-        if (fIsBDAP) {
+        if (fIsBDAP && !fReindex) {
             LogPrintf("%s -- BDAP tx found. Hash %s\n", __func__, hash.ToString());
             // get BDAP object
             CScript scriptBDAPOp; 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -49,7 +49,10 @@ extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
 extern bool fSendFreeTransactions;
 
-static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
+//Set the following 2 constants together
+static const unsigned int DEFAULT_KEYPOOL_SIZE = 200;
+static const int DEFAULT_RESCAN_THRESHOLD = 150;
+
 //! -paytxfee default
 static const CAmount DEFAULT_TRANSACTION_FEE = 0;
 //! -fallbackfee default
@@ -789,6 +792,8 @@ private:
 
     void ReserveEdKeyForTransactions(const std::vector<unsigned char>& pubKeyToReserve);   
 
+    bool ReserveKeyForTransactions(const CPubKey pubKeyToReserve);   
+
     std::array<char, 32> ConvertSecureVector32ToArray(const std::vector<unsigned char, secure_allocator<unsigned char> >& vIn);
 
     bool fFileBacked;
@@ -825,6 +830,11 @@ public:
     mutable CCriticalSection cs_wallet;
 
     const std::string strWalletFile;
+
+    bool fNeedToRescanTransactions = false;
+    CBlockIndex* rescan_index = nullptr;
+    int ReserveKeyCount = 0;
+    bool SaveRescanIndex = false;
 
     bool WalletNeedsUpgrading()
     {
@@ -1148,7 +1158,7 @@ public:
     size_t EdKeypoolCountExternalKeys();
     size_t EdKeypoolCountInternalKeys();
     bool SyncEdKeyPool(); 
-    bool TopUpKeyPoolCombo(unsigned int kpSize = 0);
+    bool TopUpKeyPoolCombo(unsigned int kpSize = 0, bool fIncreaseSize = false);
     void ReserveKeysFromKeyPools(int64_t& nIndex, CKeyPool& keypool, CEdKeyPool& edkeypool, bool fInternal);
     void KeepKey(int64_t nIndex);
     void ReturnKey(int64_t nIndex, bool fInternal);


### PR DESCRIPTION
- Fix issue where ConnectBlock wasn't successful after DisconnectBlock when restarting Dynamic within 10 blocks
- Lower size of keypools, and increase them dynamically when reserved objects exceed initial size