### PR TITLE
v2.4-WIP Fixes

### DIFF
--- a/src/dynode.cpp
+++ b/src/dynode.cpp
@@ -229,7 +229,7 @@ void CDynode::Check(bool fForce)
         LogPrint("dynode", "CDynode::Check -- outpoint=%s, GetAdjustedTime()=%d, fSentinelPingExpired=%d\n",
             outpoint.ToStringShort(), GetAdjustedTime(), fSentinelPingExpired);
 
-        if (fSentinelPingExpired) {
+        if (sporkManager.IsSporkActive(SPORK_14_REQUIRE_SENTINEL_FLAG) && fSentinelPingExpired) {
             nActiveState = DYNODE_SENTINEL_PING_EXPIRED;
             if (nActiveStatePrev != nActiveState) {
                 LogPrint("dynode", "CDynode::Check -- Dynode %s is in %s state now\n", outpoint.ToStringShort(), GetStateString());
@@ -258,7 +258,7 @@ void CDynode::Check(bool fForce)
         LogPrint("dynode", "CDynode::Check -- outpoint=%s, GetAdjustedTime()=%d, fSentinelPingExpired=%d\n",
             outpoint.ToStringShort(), GetAdjustedTime(), fSentinelPingExpired);
 
-        if (fSentinelPingExpired) {
+        if (sporkManager.IsSporkActive(SPORK_14_REQUIRE_SENTINEL_FLAG) && fSentinelPingExpired) {
             nActiveState = DYNODE_SENTINEL_PING_EXPIRED;
             if (nActiveStatePrev != nActiveState) {
                 LogPrint("dynode", "CDynode::Check -- Dynode %s is in %s state now\n", outpoint.ToStringShort(), GetStateString());

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -60,6 +60,9 @@ CTxOut::CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn, int nRoundsIn)
 
 bool CTxOut::IsBDAP() const
 {
+    if (scriptPubKey.size() < 2)
+        return false;
+
     opcodetype opcode;
     CScript::const_iterator pc = scriptPubKey.begin();
     if (!scriptPubKey.GetOp(pc, opcode))


### PR DESCRIPTION
- When txout script is too short, do not evaluate for BDAP. Fixes `getblocktemplate` RPC.
- Don't set sentinel ping expired when spork is inactive. 