### PR TITLE
BDAP Testnet v2.4.27 Update

### DIFF
--- a/contrib/gitian-descriptors/gitian-arm.yml
+++ b/contrib/gitian-descriptors/gitian-arm.yml
@@ -1,5 +1,5 @@
 ---
-name: "dynamic-arm-2.4.26.0"
+name: "dynamic-arm-2.4.27.0"
 enable_cache: true
 suites:
 - "trusty"

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "dynamic-linux-2.4.26.0"
+name: "dynamic-linux-2.4.27.0"
 enable_cache: true
 suites:
 - "trusty"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "dynamic-osx-2.4.26.0"
+name: "dynamic-osx-2.4.27.0"
 enable_cache: true
 suites:
 - "trusty"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -1,5 +1,5 @@
 ---
-name: "dynamic-2.4.26.0"
+name: "dynamic-2.4.27.0"
 enable_cache: true
 suites:
 - "trusty"

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -19,7 +19,7 @@
 //! These need to be macros, as clientversion.cpp's and dynamic*-res.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR 2
 #define CLIENT_VERSION_MINOR 4
-#define CLIENT_VERSION_REVISION 26
+#define CLIENT_VERSION_REVISION 27
 #define CLIENT_VERSION_BUILD 0
 
 //! Set to true for release, false for prerelease or test build

--- a/src/rpc/wallet.cpp
+++ b/src/rpc/wallet.cpp
@@ -1139,10 +1139,10 @@ UniValue getbalance(const JSONRPCRequest& request)
             std::list<COutputEntry> listSent;
             wtx.GetAmounts(listReceived, listSent, allFee, strSentAccount, filter);
             if ((wtx.GetDepthInMainChain() >= nMinDepth) || (fAddLocked && wtx.IsLockedByInstantSend())) {
-                BOOST_FOREACH (const COutputEntry& r, listReceived)
+                for (const COutputEntry& r : listReceived)
                     nBalance += r.amount;
             }
-            BOOST_FOREACH (const COutputEntry& s, listSent)
+            for (const COutputEntry& s : listSent)
                 nBalance -= s.amount;
             nBalance -= allFee;
         }

--- a/src/rpc/wallet.cpp
+++ b/src/rpc/wallet.cpp
@@ -520,7 +520,7 @@ void SendBDAPTransaction(const CScript& bdapDataScript, const CScript& bdapOPScr
 void SendLinkingTransaction(const CScript& bdapDataScript, const CScript& bdapOPScript, const CScript& stealthScript, 
                                 CWalletTx& wtxNew, const CAmount& nOneTimeFee, const CAmount& nDepositFee, const bool fUseInstantSend)
 {
-    CAmount curBalance = pwalletMain->GetBalance();
+    CAmount curBalance = pwalletMain->GetBalance() + pwalletMain->GetBDAPDynamicAmount();
 
     // Check amount
     if (nOneTimeFee <= 0)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2565,6 +2565,11 @@ bool CWalletTx::IsEquivalentTo(const CWalletTx& _tx) const
     return CTransaction(tx1) == CTransaction(tx2);
 }
 
+bool CWalletTx::IsBDAP() const
+{
+    return tx->nVersion == BDAP_TX_VERSION ? true : false;
+}
+
 std::vector<uint256> CWallet::ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman)
 {
     std::vector<uint256> result;
@@ -2626,7 +2631,7 @@ CAmount CWallet::GetBalance() const
         LOCK2(cs_main, cs_wallet);
         for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
             const CWalletTx* pcoin = &(*it).second;
-            if (pcoin->IsTrusted())
+            if (pcoin->IsTrusted() && !pcoin->IsBDAP())
                 nTotal += pcoin->GetAvailableCredit();
         }
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2896,6 +2896,34 @@ void CWallet::GetBDAPCoins(std::vector<COutput>& vCoins, const CScript& prevScri
     }
 }
 
+CAmount CWallet::GetBDAPCredits() const
+{
+    std::vector<std::pair<CTxOut, COutPoint>> vCredits;
+    pwalletMain->AvailableBDAPCredits(vCredits);
+    CAmount nTotalCredits = 0;
+    for (const std::pair<CTxOut, COutPoint>& credit : vCredits) {
+        int opCode1 = -1; int opCode2 = -1;
+        std::vector<std::vector<unsigned char>> vvch;
+        credit.first.GetBDAPOpCodes(opCode1, opCode2, vvch);
+        std::string strOpType = GetBDAPOpTypeString(opCode1, opCode2);
+        const CDynamicAddress address = GetScriptAddress(credit.first.scriptPubKey);
+        if (strOpType == "bdap_move_asset") {
+            if (vvch.size() > 1) {
+                std::string strMoveDestination = stringFromVch(vvch[1]);
+                if (strMoveDestination == "BDAP") {
+                    nTotalCredits += credit.first.nValue;
+                }
+            }
+        }
+    }
+    return nTotalCredits;
+}
+
+CAmount CWallet::GetBDAPDynamicAmount() const
+{
+    return (GetBDAPCredits() * BDAP_CREDIT);
+}
+
 void CWallet::AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed, const CCoinControl* coinControl, bool fIncludeZeroValue, AvailableCoinsType nCoinType, bool fUseInstantSend, bool fUseBDAP) const
 {
     vCoins.clear();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -537,6 +537,7 @@ public:
     bool RelayWalletTransaction(CConnman* connman, const std::string& strCommand = "tx");
 
     std::set<uint256> GetConflicts() const;
+    bool IsBDAP() const;
 };
 
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -983,6 +983,14 @@ public:
      */
     void GetBDAPCoins(std::vector<COutput>& vCoins, const CScript& prevScriptPubKey) const;
     /**
+     * return BDAP Credit anmount
+     */
+    CAmount GetBDAPCredits() const;
+    /**
+     * return BDAP Credits in Dynamic
+     */
+    CAmount GetBDAPDynamicAmount() const;
+    /**
      * Shuffle and select coins until nTargetValue is reached while avoiding
      * small change; This method is stochastic for some inputs and upon
      * completion the coin set and corresponding actual target value is


### PR DESCRIPTION
- Remove BDAP credits from wallet GetBalance() method.
- Fix send BDAP transaction after removing credits from wallet GetBalance() method
- Bump client version to v2.4.27
