### PR TITLE
Add additional X509 Certificate Support

### DIFF
--- a/src/bdap/x509certificate.cpp
+++ b/src/bdap/x509certificate.cpp
@@ -172,30 +172,6 @@ uint256 CX509Certificate::GetIssuerHash() const
     return Hash(dsX509Certificate.begin(), dsX509Certificate.end());
 }
 
-// bool CX509Certificate::SetSerialNumber() 
-// {
-//     //don't overwrite if already assigned
-//     if (SerialNumber.size() > 0) {
-//         return false;
-//     }
-    
-//     //if subject and issuer not assigned, error out
-//     if ((Subject.size() == 0) || (Issuer.size() == 0)) {
-//         return false;
-//     }
-
-//     int64_t now = GetTimeMillis();  
-//     uint256 hash;
-//     CDataStream dsX509Certificate(SER_NETWORK, PROTOCOL_VERSION);
-//     dsX509Certificate << Subject << Issuer << std::to_string(now);
-//     hash = Hash(dsX509Certificate.begin(), dsX509Certificate.end());
-//     std::vector<unsigned char> vchSerialNumber(hash.begin(), hash.end());
-
-//     SerialNumber = vchSerialNumber;
-
-//     return true;
-// }
-
 bool CX509Certificate::SignSubject(const std::vector<unsigned char>& vchPubKey, const std::vector<unsigned char>& vchPrivKey)
 {
     std::vector<unsigned char> msg = vchFromString(GetSubjectHash().ToString());

--- a/src/bdap/x509certificate.cpp
+++ b/src/bdap/x509certificate.cpp
@@ -168,7 +168,7 @@ uint256 CX509Certificate::GetSubjectHash() const
 uint256 CX509Certificate::GetIssuerHash() const
 {
     CDataStream dsX509Certificate(SER_NETWORK, PROTOCOL_VERSION);
-    dsX509Certificate << MonthsValid << Subject << SubjectSignature << Issuer << SubjectPublicKey << SerialNumber << PEM;
+    dsX509Certificate << MonthsValid << Subject << SubjectSignature << Issuer << SubjectPublicKey << IssuerPublicKey << SerialNumber << PEM;
     return Hash(dsX509Certificate.begin(), dsX509Certificate.end());
 }
 

--- a/src/bdap/x509certificate.cpp
+++ b/src/bdap/x509certificate.cpp
@@ -5,12 +5,13 @@
 #include "bdap/x509certificate.h"
 #include "bdap/utils.h"
 #include "hash.h"
+#include "policy/policy.h"
 #include "script/script.h"
 #include "streams.h"
+#include "txmempool.h"
 #include "uint256.h"
-#include "validation.h"
-
 #include "util.h"
+#include "validation.h"
 
 #include "dht/ed25519.h"
 #include <libtorrent/ed25519.hpp>
@@ -214,6 +215,28 @@ bool CX509Certificate::CheckIssuerSignature(const std::vector<unsigned char>& vc
     }
 
     return true;
+}
+
+/** Checks if certificate transaction exists in the memory pool */
+bool CX509Certificate::CheckIfExistsInMemPool(const CTxMemPool& pool, std::string& errorMessage)
+{
+    for (const CTxMemPoolEntry& e : pool.mapTx) {
+        const CTransactionRef& tx = e.GetSharedTx();
+        if (tx->nVersion != BDAP_TX_VERSION) {
+            continue;
+        } 
+        //TODO: debug make sure it's hitting this
+        for (const CTxOut& txOut : tx->vout) {
+            if (IsBDAPDataOutput(txOut)) {
+                CX509Certificate certificate(tx);
+                if ((this->Subject == certificate.Subject) && (this->Issuer == certificate.Issuer)) {
+                    errorMessage = "CheckIfExistsInMemPool: A certificate transaction for subject " + stringFromVch(Subject) + " and issuer " + stringFromVch(Issuer) +" is already in the memory pool!";
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
 }
 
 int add_ext(X509 *cert, int nid, char *value)

--- a/src/bdap/x509certificate.h
+++ b/src/bdap/x509certificate.h
@@ -181,6 +181,8 @@ public:
     bool X509Export(const std::vector<unsigned char>& vchSubjectPrivSeedBytes, std::string filename = "");  //Pass PrivSeedBytes
     bool X509ExportRoot(std::string filename = "");
 
+    bool CheckIfExistsInMemPool(const CTxMemPool& pool, std::string& errorMessage);
+
     std::string GetPEMSubject() const;
     std::string GetReqPEMSubject() const;
     std::string GetPEMIssuer() const;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -10,6 +10,7 @@
 #include "base58.h"
 #include "bdap/domainentry.h"
 #include "bdap/utils.h"
+#include "bdap/x509certificate.h"
 #include "consensus/consensus.h"
 #include "fluid/fluid.h"
 #include "instantsend.h"
@@ -281,7 +282,18 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet* 
                             sub.type = TransactionRecord::NewCertificate;
                         }
                         else if (strOpType == "bdap_approve_certificate" ) {
-                            sub.type = TransactionRecord::ApproveCertificate;
+                            //need to distinguish if this is a root certificate for Qt GUI
+                            std::vector<unsigned char> vchData;
+                            std::vector<unsigned char> vchHash;
+                            CX509Certificate certificate;
+                            GetBDAPData(txout, vchData, vchHash);
+                            certificate.UnserializeFromData(vchData, vchHash);
+                            if (certificate.IsRootCA) {
+                                sub.type = TransactionRecord::ApproveRootCertificate;
+                            }
+                            else {
+                               sub.type = TransactionRecord::ApproveCertificate;
+                            }
                         }
                     }
                 }

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -106,7 +106,8 @@ public:
         PrivateSend,
         NewAudit,
         NewCertificate,
-        ApproveCertificate
+        ApproveCertificate,
+        ApproveRootCertificate
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -386,9 +386,11 @@ QString TransactionTableModel::formatTxType(const TransactionRecord* wtx) const
     case TransactionRecord::NewAudit:
         return tr("BDAP Audit");
     case TransactionRecord::NewCertificate:
-        return tr("BDAP Certificate Request");
+        return tr("BDAP X509 Certificate Request");
     case TransactionRecord::ApproveCertificate:
-        return tr("BDAP Certificate Approved");
+        return tr("BDAP X509 Certificate Approved");
+    case TransactionRecord::ApproveRootCertificate:
+        return tr("New BDAP X509 Root Certificate");
     case TransactionRecord::PrivateSendDenominate:
         return tr("PrivateSend Denominate");
     case TransactionRecord::PrivateSendCollateralPayment:
@@ -447,6 +449,8 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord* wtx
         return QIcon(":/icons/" + theme + "/bdap");
     case TransactionRecord::ApproveCertificate:
         return QIcon(":/icons/" + theme + "/bdap");
+    case TransactionRecord::ApproveRootCertificate:
+        return QIcon(":/icons/" + theme + "/bdap");
     case TransactionRecord::LinkRequest:
     case TransactionRecord::LinkAccept:
         return QIcon(":/icons/" + theme + "/bdap");
@@ -504,6 +508,8 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord* wtx, b
         return tr("Certificate Request Entry");
     case TransactionRecord::ApproveCertificate:
         return tr("Certificate Approved Entry");
+    case TransactionRecord::ApproveRootCertificate:
+        return tr("Certificate Root Entry");
     case TransactionRecord::SendToSelf:
     default:
         return tr("(n/a)") + watchAddress;
@@ -530,6 +536,7 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord* wtx) const
     case TransactionRecord::NewAudit:
     case TransactionRecord::NewCertificate:
     case TransactionRecord::ApproveCertificate:
+    case TransactionRecord::ApproveRootCertificate:
     case TransactionRecord::UpdateDomainUser:
     case TransactionRecord::DeleteDomainUser:
     case TransactionRecord::RevokeDomainUser:

--- a/src/rpc/certificates.cpp
+++ b/src/rpc/certificates.cpp
@@ -564,6 +564,8 @@ static UniValue ApproveCertificate(const JSONRPCRequest& request)
     privCertificateKeyPubKeyString = ToHex(&privCertificateKeyPubKeyBytes[0],32);
     privCertificateKeyPubKey = std::vector<unsigned char>(privCertificateKeyPubKeyString.begin(), privCertificateKeyPubKeyString.end());
 
+    txCertificate.IssuerPublicKey = privCertificateKeyPubKeyBytes;
+
     CKeyID vchCertificatePubKeyIDIssuer = GetIdFromCharVector(privCertificateKeyPubKey);
     if (!pwalletMain->GetDHTKey(vchCertificatePubKeyIDIssuer, privIssuerCertificateKey))
         throw std::runtime_error("BDAP_CERTIFICATE_APPROVE_RPC_ERROR: Unable to retrieve Issuer Certificate Key");

--- a/src/rpc/certificates.cpp
+++ b/src/rpc/certificates.cpp
@@ -261,9 +261,9 @@ static UniValue NewCertificate(const JSONRPCRequest& request)
             " \"approve_height\"            (int, optional)      Block where approval is stored \n"
             "}\n"
             "\nExamples\n" +
-           HelpExampleCli("certificate new", "\"subject\" (\"issuer\") \"key_usage_array\" ") +
+           HelpExampleCli("certificate new", "\"subject\" \"issuer\" ") +
            "\nAs a JSON-RPC call\n" + 
-           HelpExampleRpc("certificate new", "\"subject\" (\"issuer\")  \"key_usage_array\" "));
+           HelpExampleRpc("certificate new", "\"subject\" \"issuer\" "));
 
     EnsureWalletIsUnlocked();
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1155,14 +1155,20 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
                 return state.Invalid(false, REJECT_ALREADY_KNOWN, "bdap-audit-already-exists");
 
         } else if (strOpType == "bdap_new_certificate" || strOpType == "bdap_approve_certificate") {
+            if (!sporkManager.IsSporkActive(SPORK_32_BDAP_V2))
+                return state.DoS(0, false, REJECT_NONSTANDARD, "inactive-spork-bdap-v2-tx");
+
             std::string errorPrefix = "bdap-new-certificate-";
 
             if (strOpType == "bdap_approve_certificate") {
                 errorPrefix = "bdap-approve-certificate-";
             }
 
-            if (!sporkManager.IsSporkActive(SPORK_32_BDAP_V2))
-                return state.DoS(0, false, REJECT_NONSTANDARD, "inactive-spork-bdap-v2-tx");
+            CX509Certificate certificate(ptx);
+
+            if (certificate.CheckIfExistsInMemPool(mempool, strErrorMessage)) {
+                return state.Invalid(false, REJECT_INVALID, errorPrefix + "already-exists-in-mempool");
+            }
 
             if (vvch.size() < 5)
                 return state.Invalid(false, REJECT_INVALID, errorPrefix + "not-enough-parameters");
@@ -1186,7 +1192,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             }
 
             // check bdap accounts and signature is correct.
-            CX509Certificate certificate(ptx);
             CDomainEntry findSubjectDomainEntry;
             CDomainEntry findIssuerDomainEntry;
             std::string errorMessage;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1231,11 +1231,13 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
                 }
                 vchIssuerPubKey = findIssuerDomainEntry.DHTPublicKey;
 
-                //only check subject signature if NOT self signed because PEM gets modified
+                //only check subject signature if NOT self signed and NOT approved because PEM gets modified [so check for REQUEST only]
                 //Check Subject Signature
-                if (!certificate.CheckSubjectSignature(EncodedPubKeyToBytes(vchSubjectPubKey))) {
-                    strErrorMessage = "AcceptToMemoryPoolWorker -- Invalid signature.  Rejected by the tx memory pool!";
-                    return state.Invalid(false, REJECT_INVALID, errorPrefix + "check-subject-signature-failed " + strErrorMessage);
+                if (!certificate.IsApproved()) {
+                    if (!certificate.CheckSubjectSignature(EncodedPubKeyToBytes(vchSubjectPubKey))) {
+                        strErrorMessage = "AcceptToMemoryPoolWorker -- Invalid signature.  Rejected by the tx memory pool!";
+                        return state.Invalid(false, REJECT_INVALID, errorPrefix + "check-subject-signature-failed " + strErrorMessage);
+                    }
                 }
             }
             else {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -11,6 +11,7 @@
 
 #include "base58.h"
 #include "bdap/bdap.h"
+#include "bdap/certificatedb.h"
 #include "bdap/domainentrydb.h"
 #include "bdap/linkingdb.h"
 #include "bdap/linkstorage.h"
@@ -4347,7 +4348,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     txin.scriptSig = CScript();
                 }
 
-                //TODO: Check if audit and certificate are in mempool
+                //TODO: Check if audits are in mempool
                 if (fIsBDAP) {
                     if (strOpType == "bdap_new_account" || strOpType == "bdap_delete_account" || strOpType == "bdap_update_account") {
                         // Check the memory pool for a pending tranaction for the same domain entry
@@ -4357,6 +4358,19 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                             return false;
                         }
                     }
+
+                    //certificates
+                    if (strOpType == "bdap_new_certificate" || strOpType == "bdap_approve_certificate") {
+                        // Check the memory pool for a pending tranaction for the same certificate (subject)
+                        CTransactionRef pTxNew = MakeTransactionRef(txNew);
+                        CX509Certificate certificate(pTxNew);
+                        if (certificate.CheckIfExistsInMemPool(mempool, strFailReason)) {
+                            return false;
+                        }
+                    }
+
+                    //TODO: audits (need to check all audit hashes)
+
                 }
 
                 // Allow to override the default confirmation target over the CoinControl instance


### PR DESCRIPTION
[BDAP] Cleanup unnecessary code in X509Certificate
[BDAP] Fix AcceptToMemoryPoolWorker logic in validation.cpp
[BDAP] Fix issues and update functionality in Certificate RPC
[BDAP] Assign IssuerPublicKey when approving and include in GetIssuer… …
[BDAP] Add CheckIfExistsInMemPool method to X509Certificate
[BDAP] Update help info for NewCertificate RPC
[BDAP] Add certificate CheckIfExistsInMemPool check in wallet.cpp
[BDAP] Add certificate CheckIfExistsInMemPool check in validation.cpp
[Qt] Update certificate verbiage in Transactions GUI and distinguish … …
[BDAP] Add ViewPending method to Certificate RPC. Additional tweaks/e… …