### PR TITLE
backport: Update Boost download URL due to mirror sunsetting

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,6 +1,6 @@
 package=boost
 $(package)_version=1_67_0
-$(package)_download_path=https://dl.bintray.com/boostorg/release/1.67.0/source/
+$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba
 


### PR DESCRIPTION
See bitcoin@36c10b9 from https://github.com/bitcoin/bitcoin/pull/21662/commits
