### PR TITLE
Tests: Add stealth_tests to unit test binary

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -94,6 +94,7 @@ DYNAMIC_TESTS =\
   test/sighash_tests.cpp \
   test/sigopcount_tests.cpp \
   test/skiplist_tests.cpp \
+  test/stealth_tests.cpp \
   test/streams_tests.cpp \
   test/test_dynamic.cpp \
   test/test_dynamic.h \


### PR DESCRIPTION
<!--- Remove sections that do not apply -->
### What is the purpose of this pull request (PR)?
Fixes stealth address unit tests used by BDAP links. Previously, it wasn't built with the unit test binary. Adding it to the make file fixed the issue.

#### Was this PR tested and how? (If testing is not needed, please explain why)
Yes, it was tested by running the unit test on Ubuntu 18.04:
```
./src/test/test_dynamic --run_test=stealth_tests
Running 3 test cases...
Exit: stealth_test1
Exit: stealth_test1_negative
Exit: stealth_test2

*** No errors detected
```
#### Does this PR resolve an open issue (reference issue #)?
This issue was reported by a developer (Alex) and no issue was added to the repo.